### PR TITLE
pooled vcat

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -212,6 +212,22 @@ end
 
             convert($A{T, N, R}, A)
         end
+
+        function Base.vcat{T,N,R}(A1::$A{T, N, R}, An::$A...)
+            As = (A1, An...)
+            levels = unique(T[[a.pool.levels for a in As]...;])
+
+            ordered = A1.pool.ordered
+            if ordered && levels != A1.pool.levels
+                warn("Failed to preserve ordered pool since not all levels were definied in the first $($A).")
+                ordered = false
+            else
+                # ignoring ordering in An...
+            end
+
+            refs = DefaultRefType[[indexin(a.pool.index, levels)[a.refs] for a in As]...;]
+            $A(refs, CategoricalPool(levels, ordered))
+        end
     end
 end
 

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -539,7 +539,7 @@ for isordered in (false, true)
             @test isa(r, CategoricalArray{Int,1,CategoricalArrays.DefaultRefType})
             @test isa(vcat(cca1, ca2), CategoricalArray{Int,1,CategoricalArrays.DefaultRefType})
             @test ordered(r) == false
-            @test sort(levels(r)) == collect(3:300)
+            @test levels(r) == collect(3:300)
 
             # Test vcat of multidimensional arrays
             a1 = Array{Int}(2,3,4,5)
@@ -554,7 +554,7 @@ for isordered in (false, true)
             @test r == vcat(a1, a2)
             @test isa(r, CategoricalArray{Int,4,CategoricalArrays.DefaultRefType})
             @test ordered(r) == false
-            @test sort(levels(r)) == collect(3:length(a2)+10)
+            @test levels(r) == collect(3:length(a2)+10)
 
             # Test that sortedmerge handles mutually compatible ordering
             @test CategoricalArrays.mergelevels([6,3,4,7],[2,3,5,4],[2,4,8]) == ([6,2,3,5,4,7,8],true)

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -546,15 +546,26 @@ for isordered in (false, true)
             @test r == vcat(a1, a2)
             @test isa(r, CategoricalArray{Int,4,CategoricalArrays.DefaultRefType})
 
+            # All levels has to be present in the first argument to vcat to preserve ordering
             a1 = ["Old", "Young", "Young"]
-            ca1 = CategoricalArray(a1, ordered=true)
-            levels!(ca1, ["Young", "Middle", "Old"])
             a2 = ["Old", "Young", "Middle", "Young"]
+            ca1 = CategoricalArray(a1, ordered=true)
             ca2 = CategoricalArray(a2)
+            levels!(ca1, ["Young", "Middle", "Old"])
             r = vcat(ca1, ca2)
             @test r == vcat(a1, a2)
             @test isa(r, CategoricalArray{ASCIIString,1,CategoricalArrays.DefaultRefType})
             @test levels(r) == ["Young", "Middle", "Old"]
+
+            # This would throw a warning about mixing ordering and return a
+            # categorical array with ordered=false.
+            #a1 = ["Old", "Young", "Middle", "Young"]
+            #a2 = ["Old", "Young", "Young"]
+            #ca1 = CategoricalArray(a1, ordered=true)
+            #ca2 = CategoricalArray(a2, ordered=true)
+            #levels!(ca1, ["Old", "Young", "Middle"])
+            #levels!(ca2, ["Young", "Old"])
+            #@test vcat(ca1, ca2) == vcat(a1, a2)
         end
     end
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -556,16 +556,25 @@ for isordered in (false, true)
             @test r == vcat(a1, a2)
             @test isa(r, CategoricalArray{ASCIIString,1,CategoricalArrays.DefaultRefType})
             @test levels(r) == ["Young", "Middle", "Old"]
+            @test ordered(r) == true
 
-            # This would throw a warning about mixing ordering and return a
-            # categorical array with ordered=false.
-            #a1 = ["Old", "Young", "Middle", "Young"]
-            #a2 = ["Old", "Young", "Young"]
-            #ca1 = CategoricalArray(a1, ordered=true)
-            #ca2 = CategoricalArray(a2, ordered=true)
-            #levels!(ca1, ["Old", "Young", "Middle"])
-            #levels!(ca2, ["Young", "Old"])
-            #@test vcat(ca1, ca2) == vcat(a1, a2)
+            #=
+            # Test concatenation of ambiguous ordering. This prints a warning about
+            # mixing ordering and returns a categorical array with ordered=false.
+            levels!(ca1, ["Young", "Old"])
+            levels!(ca2, ["Old", "Young", "Middle"])
+            ordered!(ca1,true)
+            ordered!(ca2,true)
+            println("Expect warning: Failed to preserve order of levels. Define all levels in the first argument.")
+            r = vcat(ca1, ca2)
+            @test r == vcat(a1, a2)
+            @test ordered(r) == false
+
+            println("Expect warning: Failed to preserve order of levels. The first argument defines the levels and their order.")
+            r = vcat(ca2, ca1)
+            @test r == vcat(a2, a1)
+            @test ordered(r) == false
+            =#
         end
     end
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -546,35 +546,32 @@ for isordered in (false, true)
             @test r == vcat(a1, a2)
             @test isa(r, CategoricalArray{Int,4,CategoricalArrays.DefaultRefType})
 
-            # All levels has to be present in the first argument to vcat to preserve ordering
-            a1 = ["Old", "Young", "Young"]
-            a2 = ["Old", "Young", "Middle", "Young"]
+            # Test that sortedmerge handles mutually compatible ordering
+            @test CategoricalArrays.sortedmerge([6,3,4,7],[2,3,5,4]) == ([6,2,3,5,4,7],true)
+
+            # Test concatenation of mutually compatible levels
+            a1 = ["Young", "Middle"]
+            a2 = ["Middle", "Old"]
             ca1 = CategoricalArray(a1, ordered=true)
-            ca2 = CategoricalArray(a2)
-            levels!(ca1, ["Young", "Middle", "Old"])
+            ca2 = CategoricalArray(a2, ordered=true)
+            levels!(ca1, ["Young", "Middle"])
+            levels!(ca2, ["Middle", "Old"])
             r = vcat(ca1, ca2)
             @test r == vcat(a1, a2)
-            @test isa(r, CategoricalArray{ASCIIString,1,CategoricalArrays.DefaultRefType})
             @test levels(r) == ["Young", "Middle", "Old"]
             @test ordered(r) == true
 
-            #=
-            # Test concatenation of ambiguous ordering. This prints a warning about
-            # mixing ordering and returns a categorical array with ordered=false.
-            levels!(ca1, ["Young", "Old"])
-            levels!(ca2, ["Old", "Young", "Middle"])
-            ordered!(ca1,true)
-            ordered!(ca2,true)
-            println("Expect warning: Failed to preserve order of levels. Define all levels in the first argument.")
+            # Test concatenation of ambiguous ordering. This drops the ordering
+            a1 = ["Old", "Young", "Young"]
+            a2 = ["Old", "Young", "Middle", "Young"]
+            ca1 = CategoricalArray(a1, ordered=true)
+            ca2 = CategoricalArray(a2, ordered=true)
+            levels!(ca1, ["Young", "Middle", "Old"])
+            # ca2 has another order
             r = vcat(ca1, ca2)
             @test r == vcat(a1, a2)
+            @test levels(r) == ["Young", "Middle", "Old"]
             @test ordered(r) == false
-
-            println("Expect warning: Failed to preserve order of levels. The first argument defines the levels and their order.")
-            r = vcat(ca2, ca1)
-            @test r == vcat(a2, a1)
-            @test ordered(r) == false
-            =#
         end
     end
 end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -522,6 +522,39 @@ for isordered in (false, true)
             @test x[1] === x.pool.valindex[3]
             @test x[2] === x.pool.valindex[1]
             @test levels(x) == ["c", "a", "b"]
+
+            a1 = 3:200
+            a2 = 300:-1:100
+            ca1 = CategoricalArray(a1)
+            ca2 = CategoricalArray(a2)
+            cca1 = compact(ca1)
+            cca2 = compact(ca2)
+            r = vcat(cca1, cca2)
+            @test r == vcat(a1, a2)
+            @test isa(r, CategoricalArray{Int,1,CategoricalArrays.DefaultRefType})
+            @test isa(vcat(cca1, ca2), CategoricalArray{Int,1,CategoricalArrays.DefaultRefType})
+
+            a1 = Array{Int}(2,3,4,5)
+            a2 = Array{Int}(3,3,4,5)
+            a1[1:end] = (length(a1):-1:1) + 2
+            a2[1:end] = (1:length(a2)) + 10
+            ca1 = CategoricalArray(a1)
+            ca2 = CategoricalArray(a2)
+            cca1 = compact(ca1)
+            cca2 = compact(ca2)
+            r = vcat(cca1, cca2)
+            @test r == vcat(a1, a2)
+            @test isa(r, CategoricalArray{Int,4,CategoricalArrays.DefaultRefType})
+
+            a1 = ["Old", "Young", "Young"]
+            ca1 = CategoricalArray(a1, ordered=true)
+            levels!(ca1, ["Young", "Middle", "Old"])
+            a2 = ["Old", "Young", "Middle", "Young"]
+            ca2 = CategoricalArray(a2)
+            r = vcat(ca1, ca2)
+            @test r == vcat(a1, a2)
+            @test isa(r, CategoricalArray{ASCIIString,1,CategoricalArrays.DefaultRefType})
+            @test levels(r) == ["Young", "Middle", "Old"]
         end
     end
 end


### PR DESCRIPTION
This PR introduces three features:

1. vcat compares the unique elements in the pools only once instead of comparing each new inserted element to the accumulated pool. This is more efficient for large arrays with small pools. The translation between the individual pools and the total pool is then an O(1) operation.
2. vcat on compact arrays may overflow. Here I'm always expanding the reftype to `DefaultRefType`. I figure you'd prefer to keep compact arrays if possible but I don't know how to do that without introducing type instability.
3. For ordered levels vcat preserves the order based on the first argument. If the other arguments are ordered and doesn't comply, or if they have levels not included in the order defined by the first argument; then the returned array won't have ordered levels and a warning is shown that the ordering is dropped.

Related to https://github.com/JuliaStats/DataArrays.jl/pull/213