### PR TITLE
Improve error message when number of levels is higher than reftype max

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -5,6 +5,7 @@ module CategoricalArrays
     export AbstractNullableCategoricalArray, AbstractNullableCategoricalVector,
            AbstractNullableCategoricalMatrix,
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
+    export LevelsException
 
     export categorical, compact, droplevels!, levels, levels!, isordered, ordered!
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -282,6 +282,10 @@ end
 
         # From CategoricalArray (preserve R)
         function convert{T, N, R}(::Type{$A{T, N, R}}, A::$A)
+            if length(A.pool) > typemax(R)
+                throw(LevelsException{T, R}(levels(A)[typemax(R)+1:end]))
+            end
+
             refs = convert(Array{R, N}, A.refs)
             pool = convert(CategoricalPool{T, R}, A.pool)
             ordered!($A(refs, pool), isordered(A))

--- a/src/buildfields.jl
+++ b/src/buildfields.jl
@@ -6,7 +6,11 @@ function buildindex{S, R <: Integer}(invindex::Dict{S, R})
     return index
 end
 
-function buildinvindex{T}(index::Vector{T}, R=DefaultRefType)
+function buildinvindex{T, R}(index::Vector{T}, ::Type{R}=DefaultRefType)
+    if length(index) > typemax(R)
+        throw(LevelsException{T, R}(index[typemax(R)+1:end]))
+    end
+
     invindex = Dict{T, R}()
     for (i, v) in enumerate(index)
         invindex[v] = i

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -23,6 +23,10 @@ type CategoricalPool{T, R <: Integer, V}
     end
 end
 
+immutable LevelsException{T, R} <: Exception
+    levels::Vector{T}
+end
+
 ## Values
 
 immutable CategoricalValue{T, R <: Integer}

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -233,6 +233,47 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
         @test levels(x) == ["X", "Young", "Middle", "Old"]
         @test !isordered(x)
     end
+
+
+    # Test that overflow of reftype is detected and doesn't corrupt data and levels
+
+    res = @test_throws LevelsException{Int, UInt8} CA{Int, 1, UInt8}(256:-1:1)
+    @test res.value.levels == [1]
+    @test sprint(showerror, res.value) == "cannot store level(s) 1 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+
+    x = CA{Int, 1, UInt8}(254:-1:1)
+    x[1] = 1000
+    res = @test_throws LevelsException{Int, UInt8} x[1] = 1001
+    @test res.value.levels == [1001]
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test x == A(vcat(1000, 253:-1:1))
+    @test levels(x) == vcat(1:254, 1000)
+
+    x = CA{Int, 1, UInt8}(1:254)
+    res = @test_throws LevelsException{Int, UInt8} x[1:2] = 1000:1001
+    @test res.value.levels == [1001]
+    @test sprint(showerror, res.value) == "cannot store level(s) 1001 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test x == A(vcat(1000, 2:254))
+    @test levels(x) == vcat(1:254, 1000)
+
+    x = CA{Int, 1, UInt8}([1, 3, 256])
+    res = @test_throws LevelsException{Int, UInt8} levels!(x, collect(1:256))
+    @test res.value.levels == [255]
+    @test sprint(showerror, res.value) == "cannot store level(s) 255 since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+
+    x = CA(30:2:131115)
+    res = @test_throws LevelsException{Int, UInt16} CategoricalVector{Int, UInt16}(x)
+    @test res.value.levels == collect(131100:2:131114)
+    @test sprint(showerror, res.value) == "cannot store level(s) 131100, 131102, 131104, 131106, 131108, 131110, 131112 and 131114 since reference type UInt16 can only hold 65535 levels. Convert categorical array to a larger reference type to add more levels."
+
+    x = CA{String, 1, UInt8}(string.(Char.(65:318)))
+    res = @test_throws LevelsException{String, UInt8} levels!(x, vcat(levels(x), "az", "bz", "cz"))
+    @test res.value.levels == ["bz", "cz"]
+    @test sprint(showerror, res.value) == "cannot store level(s) \"bz\" and \"cz\" since reference type UInt8 can only hold 255 levels. Convert categorical array to a larger reference type to add more levels."
+    @test x == A(string.(Char.(65:318)))
+    lev = copy(levels(x))
+    levels!(x, vcat(lev, "az"))
+    @test levels(x) == vcat(lev, "az")
 end
 
 end


### PR DESCRIPTION
The error was always caught before, but as a conversion error when trying
to convert value to insert it into dictionaries.

This commit triggers a crash reliably on Julia 0.4.6, so we need to bump
the required version. Keep compatibility code for now to allow debugging.

Fixes https://github.com/nalimilan/CategoricalArrays.jl/issues/16.

@gustaffson How does that sound?