### PR TITLE
Update ordered and levels API

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -6,7 +6,7 @@ module CategoricalArrays
            AbstractNullableCategoricalMatrix,
            NullableCategoricalArray, NullableCategoricalVector, NullableCategoricalMatrix
 
-    export categorical, compact, droplevels!, levels, levels!, ordered, ordered!
+    export categorical, compact, droplevels!, levels, levels!, isordered, ordered!
 
     using Compat
 
@@ -19,6 +19,7 @@ module CategoricalArrays
 
     include("array.jl")
     include("nullablearray.jl")
+    include("deprecated.jl")
 
     if VERSION < v"0.5.0-dev"
         Base.convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S, n}) = convert(Array{T, n}, x)

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,9 +3,9 @@
 import Base: convert, copy, getindex, setindex!, similar, size, linearindexing, vcat
 
 # Used for keyword argument default value
-_ordered(x::AbstractCategoricalArray) = ordered(x)
-_ordered(x::AbstractNullableCategoricalArray) = ordered(x)
-_ordered(x::Any) = false
+_isordered(x::AbstractCategoricalArray) = isordered(x)
+_isordered(x::AbstractNullableCategoricalArray) = isordered(x)
+_isordered(x::Any) = false
 
 function reftype(sz::Int)
     if sz <= typemax(UInt8)
@@ -93,7 +93,7 @@ end
 
         # This method is needed to ensure ordered!() only mutates a copy of A
         @compat function (::Type{$A{T, N, R}}){T, N, R}(A::$A{T, N, R};
-                                                        ordered=_ordered(A))
+                                                        ordered=_isordered(A))
             ret = copy(A)
             ordered!(ret, ordered)
             ret
@@ -101,50 +101,50 @@ end
 
         # Note this method is also used for CategoricalArrays when T, N or R don't match
         @compat function (::Type{$A{T, N, R}}){T, N, R}(A::AbstractArray;
-                                                        ordered=_ordered(A))
+                                                        ordered=_isordered(A))
             ret = convert($A{T, N, R}, A)
             ordered!(ret, ordered)
             ret
         end
 
         @compat (::Type{$A{T, N, R}}){T<:CategoricalValue, N, R}(A::AbstractArray;
-                                                                 ordered=_ordered(A)) =
+                                                                 ordered=_isordered(A)) =
             $A{T.parameters[1], N, R}(A, ordered=ordered)
 
         # From AbstractArray
-        @compat (::Type{$A{T, N}}){S, T, N}(A::AbstractArray{S, N}; ordered=_ordered(A)) =
+        @compat (::Type{$A{T, N}}){S, T, N}(A::AbstractArray{S, N}; ordered=_isordered(A)) =
             $A{T, N, DefaultRefType}(A, ordered=ordered)
-        @compat (::Type{$A{T}}){S, T, N}(A::AbstractArray{S, N}; ordered=_ordered(A)) =
+        @compat (::Type{$A{T}}){S, T, N}(A::AbstractArray{S, N}; ordered=_isordered(A)) =
             $A{T, N}(A, ordered=ordered)
-        @compat (::Type{$A}){T, N}(A::AbstractArray{T, N}; ordered=_ordered(A)) =
+        @compat (::Type{$A}){T, N}(A::AbstractArray{T, N}; ordered=_isordered(A)) =
             $A{T, N}(A, ordered=ordered)
 
-        @compat (::Type{$V{T}}){S, T}(A::AbstractVector{S}; ordered=_ordered(A)) =
+        @compat (::Type{$V{T}}){S, T}(A::AbstractVector{S}; ordered=_isordered(A)) =
             $A{T, 1}(A, ordered=ordered)
-        @compat (::Type{$V}){T}(A::AbstractVector{T}; ordered=_ordered(A)) =
+        @compat (::Type{$V}){T}(A::AbstractVector{T}; ordered=_isordered(A)) =
             $A{T, 1}(A, ordered=ordered)
 
-        @compat (::Type{$M{T}}){S, T}(A::AbstractMatrix{S}; ordered=_ordered(A)) =
+        @compat (::Type{$M{T}}){S, T}(A::AbstractMatrix{S}; ordered=_isordered(A)) =
             $A{T, 2}(A, ordered=ordered)
-        @compat (::Type{$M}){T}(A::AbstractMatrix{T}; ordered=_ordered(A)) =
+        @compat (::Type{$M}){T}(A::AbstractMatrix{T}; ordered=_isordered(A)) =
             $A{T, 2}(A, ordered=ordered)
 
         # From CategoricalArray (preserve R)
-        @compat (::Type{$A{T, N}}){S, T, N, R}(A::$A{S, N, R}; ordered=_ordered(A)) =
+        @compat (::Type{$A{T, N}}){S, T, N, R}(A::$A{S, N, R}; ordered=_isordered(A)) =
             $A{T, N, R}(A, ordered=ordered)
-        @compat (::Type{$A{T}}){S, T, N, R}(A::$A{S, N, R}; ordered=_ordered(A)) =
+        @compat (::Type{$A{T}}){S, T, N, R}(A::$A{S, N, R}; ordered=_isordered(A)) =
             $A{T, N, R}(A, ordered=ordered)
-        @compat (::Type{$A}){T, N, R}(A::$A{T, N, R}; ordered=_ordered(A)) =
+        @compat (::Type{$A}){T, N, R}(A::$A{T, N, R}; ordered=_isordered(A)) =
             $A{T, N, R}(A, ordered=ordered)
 
-        @compat (::Type{$V{T}}){S, T, R}(A::$V{S, R}; ordered=_ordered(A)) =
+        @compat (::Type{$V{T}}){S, T, R}(A::$V{S, R}; ordered=_isordered(A)) =
             $A{T, 1, R}(A, ordered=ordered)
-        @compat (::Type{$V}){T, R}(A::$V{T, R}; ordered=_ordered(A)) =
+        @compat (::Type{$V}){T, R}(A::$V{T, R}; ordered=_isordered(A)) =
             $A{T, 1, R}(A, ordered=ordered)
 
-        @compat (::Type{$M{T}}){S, T, R}(A::$M{S, R}; ordered=_ordered(A)) =
+        @compat (::Type{$M{T}}){S, T, R}(A::$M{S, R}; ordered=_isordered(A)) =
             $A{T, 2, R}(A, ordered=ordered)
-        @compat (::Type{$M}){T, R}(A::$M{T, R}; ordered=_ordered(A)) =
+        @compat (::Type{$M}){T, R}(A::$M{T, R}; ordered=_isordered(A)) =
             $A{T, 2, R}(A, ordered=ordered)
 
 
@@ -188,7 +188,7 @@ end
             refs = convert(Array{R, N}, A.refs)
             pool = convert(CategoricalPool{T, R}, A.pool)
             ret = $A(refs, pool)
-            ordered!(ret, ordered(A))
+            ordered!(ret, isordered(A))
             ret
         end
         convert{S, T, N, R}(::Type{$A{T, N}}, A::$A{S, N, R}) =
@@ -209,7 +209,7 @@ end
         ## Other methods
 
         similar{S, T, M, N, R}(A::$A{S, M, R}, ::Type{T}, dims::NTuple{N, Int}) =
-            $A{T, N, R}(dims; ordered=ordered(A))
+            $A{T, N, R}(dims; ordered=isordered(A))
 
         function compact{T, N}(A::$A{T, N})
             R = reftype(length(index(A.pool)))
@@ -217,11 +217,11 @@ end
         end
 
         function vcat(A::$A...)
-            newlevels, isordered = mergelevels(map(levels, A)...)
+            newlevels, ordered = mergelevels(map(levels, A)...)
 
             refs = [indexin(index(a.pool), newlevels)[a.refs] for a in A]
             $A(DefaultRefType[refs...;],
-               CategoricalPool(newlevels, isordered && all(ordered, A)))
+               CategoricalPool(newlevels, ordered && all(isordered, A)))
         end
     end
 end
@@ -304,7 +304,7 @@ function droplevels!(A::CatArray)
     levels!(A, intersect(levels(A.pool), index(A.pool)[found]))
 end
 
-ordered(A::CatArray) = ordered(A.pool)
+isordered(A::CatArray) = isordered(A.pool)
 ordered!(A::CatArray, ordered) = ordered!(A.pool, ordered)
 
 function Base.push!(A::CatArray, item)
@@ -363,13 +363,13 @@ levels!(A::CategoricalArray, newlevels::Vector) = _levels!(A, newlevels)
 function mergelevels(levels...)
     T = Base.promote_eltype(levels...)
     res = Array{T}(0)
-    isordered = true
+    ordered = true
 
     for l in levels
         levelsmap = indexin(l, res)
 
-        isordered &= issorted(levelsmap[levelsmap.!=0])
-        if !isordered
+        ordered &= issorted(levelsmap[levelsmap.!=0])
+        if !ordered
             # Give up attempt to order res
             append!(res, l[levelsmap.==0])
         else
@@ -384,5 +384,5 @@ function mergelevels(levels...)
         end
     end
 
-    res, isordered
+    res, ordered
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -279,7 +279,7 @@ function _levels!(A::CatArray, newlevels::Vector; nullok=false)
         end
     end
 
-    levels(A.pool)
+    A
 end
 
 function droplevels!(A::CatArray)

--- a/src/array.jl
+++ b/src/array.jl
@@ -290,7 +290,21 @@ function droplevels!(A::CatArray)
     levels!(A, intersect(levels(A.pool), index(A.pool)[found]))
 end
 
+"""
+    isordered(A::CategoricalArray)
+
+Test whether entries in `A` can be compared using `<`, `>` and similar operators,
+using the ordering of levels.
+"""
 isordered(A::CatArray) = isordered(A.pool)
+
+"""
+    ordered!(A::CategoricalArray, ordered::Bool)
+
+Set whether entries in `A` can be compared using `<`, `>` and similar operators,
+using the ordering of levels.
+Returns the modified `A`.
+"""
 ordered!(A::CatArray, ordered) = (ordered!(A.pool, ordered); return A)
 
 function Base.push!(A::CatArray, item)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+@deprecate ordered isordered

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -58,13 +58,13 @@ end
     NullableCategoricalArray{T}((m, n); ordered=ordered)
 
 @compat (::Type{NullableCategoricalArray}){T<:Nullable}(A::AbstractArray{T};
-                                                        ordered=_ordered(A)) =
+                                                        ordered=_isordered(A)) =
     NullableCategoricalArray{eltype(T)}(A, ordered=ordered)
 @compat (::Type{NullableCategoricalVector}){T<:Nullable}(A::AbstractVector{T};
-                                                         ordered=_ordered(A)) =
+                                                         ordered=_isordered(A)) =
     NullableCategoricalVector{eltype(T)}(A, ordered=ordered)
 @compat (::Type{NullableCategoricalMatrix}){T<:Nullable}(A::AbstractMatrix{T};
-                                                         ordered=_ordered(A)) =
+                                                         ordered=_isordered(A)) =
     NullableCategoricalMatrix{eltype(T)}(A, ordered=ordered)
 
 function NullableCategoricalArray{T, N}(A::AbstractArray{T, N},

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -163,4 +163,4 @@ levels(pool::CategoricalPool) = pool.levels
 order(pool::CategoricalPool) = pool.order
 
 isordered(pool::CategoricalPool) = pool.ordered
-ordered!(pool::CategoricalPool, ordered) = pool.ordered = ordered
+ordered!(pool::CategoricalPool, ordered) = (pool.ordered = ordered; pool)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -155,7 +155,7 @@ function levels!{S, R, V}(pool::CategoricalPool{S, R, V}, newlevels::Vector)
     for (i, x) in enumerate(pool.order)
         pool.levels[x] = pool.index[i]
     end
-    return newlevels
+    return pool
 end
 
 index(pool::CategoricalPool) = pool.index

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -162,5 +162,5 @@ index(pool::CategoricalPool) = pool.index
 levels(pool::CategoricalPool) = pool.levels
 order(pool::CategoricalPool) = pool.order
 
-ordered(pool::CategoricalPool) = pool.ordered
+isordered(pool::CategoricalPool) = pool.ordered
 ordered!(pool::CategoricalPool, ordered) = pool.ordered = ordered

--- a/src/value.jl
+++ b/src/value.jl
@@ -24,7 +24,7 @@ Base.convert{S, T}(::Type{S}, x::CategoricalValue{T}) = convert(S, index(x.pool)
 function Base.show{T}(io::IO, x::CategoricalValue{T})
     if @compat(get(io, :compact, false))
         print(io, repr(index(x.pool)[x.level]))
-    elseif ordered(x.pool)
+    elseif isordered(x.pool)
         @printf(io, "%s %s (%i/%i)",
                 typeof(x),
                 repr(index(x.pool)[x.level]),
@@ -65,7 +65,7 @@ end
 function Base.isless{T}(x::CategoricalValue{T}, y::CategoricalValue{T})
     if x.pool !== y.pool
         error("CategoricalValue objects with different pools cannot be tested for order")
-    elseif !ordered(x.pool) # !ordered(y.pool) is implied by x.pool === y.pool
+    elseif !isordered(x.pool) # !isordered(y.pool) is implied by x.pool === y.pool
         error("Unordered CategoricalValue objects cannot be tested for order; use the ordered! function on the parent array to change this")
     else
         return isless(order(x.pool)[x.level], order(y.pool)[y.level])

--- a/test/07_levels.jl
+++ b/test/07_levels.jl
@@ -112,7 +112,8 @@ module TestLevels
         @test pool.valindex == [CategoricalValue(i, pool) for i in 1:5]
     end
 
-    @test levels!(pool, [1, 2, 3]) == [1, 2, 3]
+    @test levels!(pool, [1, 2, 3]) === pool
+    @test levels(pool) == [1, 2, 3]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 3
@@ -126,7 +127,8 @@ module TestLevels
     @test_throws KeyError get(pool, 10)
     @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
 
-    @test levels!(pool, [1, 2, 4]) == [1, 2, 4]
+    @test levels!(pool, [1, 2, 4]) === pool
+    @test levels(pool) == [1, 2, 4]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 3
@@ -139,7 +141,8 @@ module TestLevels
     @test_throws KeyError get(pool, 3)
     @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
 
-    @test levels!(pool, [6, 5, 4]) == [6, 5, 4]
+    @test levels!(pool, [6, 5, 4]) === pool
+    @test levels(pool) == [6, 5, 4]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 3
@@ -153,7 +156,8 @@ module TestLevels
     @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
 
     # Changing order while preserving existing levels
-    @test levels!(pool, [5, 6, 4]) == [5, 6, 4]
+    @test levels!(pool, [5, 6, 4]) === pool
+    @test levels(pool) == [5, 6, 4]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 3
@@ -167,7 +171,8 @@ module TestLevels
     @test pool.valindex == [CategoricalValue(i, pool) for i in 1:3]
 
     # Adding levels while preserving existing ones
-    @test levels!(pool, [5, 2, 3, 6, 4]) == [5, 2, 3, 6, 4]
+    @test levels!(pool, [5, 2, 3, 6, 4]) === pool
+    @test levels(pool) == [5, 2, 3, 6, 4]
 
     @test isa(pool.index, Vector{Int})
     @test length(pool) == 5

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -48,7 +48,7 @@ module TestIsLess
     @test_throws Exception v3 >= v2
     @test_throws Exception v3 >= v3
 
-    @test ordered!(pool, true) === true
+    @test ordered!(pool, true) === pool
     @test isordered(pool) === true
 
     @test (v1 < v1) === false
@@ -133,7 +133,7 @@ module TestIsLess
     @test (v3 >= v2) === true
     @test (v3 >= v3) === true
 
-    @test ordered!(pool, false) === false
+    @test ordered!(pool, false) === pool
     @test isordered(pool) === false
 
     @test_throws Exception v1 < v1

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -49,7 +49,7 @@ module TestIsLess
     @test_throws Exception v3 >= v3
 
     @test ordered!(pool, true) === true
-    @test ordered(pool) === true
+    @test isordered(pool) === true
 
     @test (v1 < v1) === false
     @test (v1 < v2) === true
@@ -134,7 +134,7 @@ module TestIsLess
     @test (v3 >= v3) === true
 
     @test ordered!(pool, false) === false
-    @test ordered(pool) === false
+    @test isordered(pool) === false
 
     @test_throws Exception v1 < v1
     @test_throws Exception v1 < v2

--- a/test/10_isless.jl
+++ b/test/10_isless.jl
@@ -91,7 +91,8 @@ module TestIsLess
     @test (v3 >= v2) === true
     @test (v3 >= v3) === true
 
-    levels!(pool, [2, 3, 1])
+    @test levels!(pool, [2, 3, 1]) === pool
+    @test levels(pool) == [2, 3, 1]
 
     @test (v1 < v1) === false
     @test (v1 < v2) === false

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -7,14 +7,14 @@ using Compat
 
 typealias String Compat.ASCIIString
 
-for isordered in (false, true)
+for ordered in (false, true)
     for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
         # Vector
         a = ["b", "a", "b"]
-        x = CategoricalVector{String, R}(a, ordered=isordered)
+        x = CategoricalVector{String, R}(a, ordered=ordered)
 
         @test x == a
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == sort(unique(a))
         @test size(x) === (3,)
         @test length(x) === 3
@@ -32,22 +32,22 @@ for isordered in (false, true)
         @test convert(CategoricalVector{String, DefaultRefType}, x) == x
         @test convert(CategoricalVector{String, UInt8}, x) == x
 
-        for y in (CategoricalArray(x, ordered=isordered),
-                  CategoricalArray{String}(x, ordered=isordered),
-                  CategoricalArray{String, 1}(x, ordered=isordered),
-                  CategoricalArray{String, 1, R}(x, ordered=isordered),
-                  CategoricalArray{String, 1, DefaultRefType}(x, ordered=isordered),
-                  CategoricalArray{String, 1, UInt8}(x, ordered=isordered),
-                  CategoricalVector(x, ordered=isordered),
-                  CategoricalVector{String}(x, ordered=isordered),
-                  CategoricalVector{String, R}(x, ordered=isordered),
-                  CategoricalVector{String, DefaultRefType}(x, ordered=isordered),
-                  CategoricalVector{String, UInt8}(x, ordered=isordered),
-                  categorical(x, ordered=isordered),
-                  categorical(x, false, ordered=isordered),
-                  categorical(x, true, ordered=isordered))
+        for y in (CategoricalArray(x, ordered=ordered),
+                  CategoricalArray{String}(x, ordered=ordered),
+                  CategoricalArray{String, 1}(x, ordered=ordered),
+                  CategoricalArray{String, 1, R}(x, ordered=ordered),
+                  CategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
+                  CategoricalArray{String, 1, UInt8}(x, ordered=ordered),
+                  CategoricalVector(x, ordered=ordered),
+                  CategoricalVector{String}(x, ordered=ordered),
+                  CategoricalVector{String, R}(x, ordered=ordered),
+                  CategoricalVector{String, DefaultRefType}(x, ordered=ordered),
+                  CategoricalVector{String, UInt8}(x, ordered=ordered),
+                  categorical(x, ordered=ordered),
+                  categorical(x, false, ordered=ordered),
+                  categorical(x, true, ordered=ordered))
             @test isa(y, CategoricalVector{String})
-            @test ordered(y) === isordered
+            @test isordered(y) === ordered
             @test y == x
             @test y !== x
             @test y.refs !== x.refs
@@ -67,53 +67,53 @@ for isordered in (false, true)
         @test convert(CategoricalVector{String, DefaultRefType}, a) == x
         @test convert(CategoricalVector{String, UInt8}, a) == x
 
-        @test CategoricalArray{String}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 1}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 1, R}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 1, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 1, UInt8}(a, ordered=isordered) == x
+        @test CategoricalArray{String}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 1, UInt8}(a, ordered=ordered) == x
 
-        @test CategoricalVector(a, ordered=isordered) == x
-        @test CategoricalVector{String}(a, ordered=isordered) == x
-        @test CategoricalVector{String, R}(a, ordered=isordered) == x
-        @test CategoricalVector{String, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalVector{String, UInt8}(a, ordered=isordered) == x
+        @test CategoricalVector(a, ordered=ordered) == x
+        @test CategoricalVector{String}(a, ordered=ordered) == x
+        @test CategoricalVector{String, R}(a, ordered=ordered) == x
+        @test CategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector{String, UInt8}(a, ordered=ordered) == x
 
         for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                      (a, DefaultRefType, DefaultRefType, false),
                                      (x, R, UInt8, true),
                                      (x, R, R, false))
-            x2 = categorical(y, ordered=isordered)
+            x2 = categorical(y, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{String, R1})
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
 
-            x2 = categorical(y, compact, ordered=isordered)
+            x2 = categorical(y, compact, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{String, R2})
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
         end
 
         x2 = compact(x)
         @test x2 == x
         @test isa(x2, CategoricalVector{String, UInt8})
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test levels(x2) == levels(x)
 
         x2 = copy(x)
         @test x2 == x
         @test typeof(x2) === typeof(x)
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test levels(x2) == levels(x)
 
-        if !ordered(x)
+        if !isordered(x)
             @test ordered!(x, true) === true
         end
         @test x[1] > x[2]
         @test x[3] > x[2]
 
         @test ordered!(x, false) === false
-        @test ordered(x) === false
+        @test isordered(x) === false
         @test_throws Exception x[1] > x[2]
         @test_throws Exception x[3] > x[2]
 
@@ -188,7 +188,7 @@ for isordered in (false, true)
         append!(x, x)
         @test length(x) == 12
         @test x == ["c", "b", "b", "a", "zz", "c", "c", "b", "b", "a", "zz", "c"]
-        @test ordered(x) === false
+        @test isordered(x) === false
         @test levels(x) == ["e", "a", "b", "c", "zz"]
 
         b = ["z","y","x"]
@@ -205,10 +205,10 @@ for isordered in (false, true)
         # Vector created from range (i.e. non-Array AbstractArray),
         # direct conversion to a vector with different eltype
         a = 0.0:0.5:1.5
-        x = CategoricalVector{Float64, R}(a, ordered=isordered)
+        x = CategoricalVector{Float64, R}(a, ordered=ordered)
 
         @test x == collect(a)
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
@@ -226,22 +226,22 @@ for isordered in (false, true)
         @test convert(CategoricalVector{Float64, DefaultRefType}, x) == x
         @test convert(CategoricalVector{Float64, UInt8}, x) == x
 
-        for y in (CategoricalArray(x, ordered=isordered),
-                  CategoricalArray{Float64}(x, ordered=isordered),
-                  CategoricalArray{Float64, 1}(x, ordered=isordered),
-                  CategoricalArray{Float64, 1, R}(x, ordered=isordered),
-                  CategoricalArray{Float64, 1, DefaultRefType}(x, ordered=isordered),
-                  CategoricalArray{Float64, 1, UInt8}(x, ordered=isordered),
-                  CategoricalVector(x, ordered=isordered),
-                  CategoricalVector{Float64}(x, ordered=isordered),
-                  CategoricalVector{Float64, R}(x, ordered=isordered),
-                  CategoricalVector{Float64, DefaultRefType}(x, ordered=isordered),
-                  CategoricalVector{Float64, UInt8}(x, ordered=isordered),
-                  categorical(x, ordered=isordered),
-                  categorical(x, false, ordered=isordered),
-                  categorical(x, true, ordered=isordered))
+        for y in (CategoricalArray(x, ordered=ordered),
+                  CategoricalArray{Float64}(x, ordered=ordered),
+                  CategoricalArray{Float64, 1}(x, ordered=ordered),
+                  CategoricalArray{Float64, 1, R}(x, ordered=ordered),
+                  CategoricalArray{Float64, 1, DefaultRefType}(x, ordered=ordered),
+                  CategoricalArray{Float64, 1, UInt8}(x, ordered=ordered),
+                  CategoricalVector(x, ordered=ordered),
+                  CategoricalVector{Float64}(x, ordered=ordered),
+                  CategoricalVector{Float64, R}(x, ordered=ordered),
+                  CategoricalVector{Float64, DefaultRefType}(x, ordered=ordered),
+                  CategoricalVector{Float64, UInt8}(x, ordered=ordered),
+                  categorical(x, ordered=ordered),
+                  categorical(x, false, ordered=ordered),
+                  categorical(x, true, ordered=ordered))
             @test isa(y, CategoricalVector{Float64})
-            @test ordered(y) === isordered
+            @test isordered(y) === ordered
             @test y == x
             @test y !== x
             @test y.refs !== x.refs
@@ -270,42 +270,42 @@ for isordered in (false, true)
         @test convert(CategoricalVector{Float64, UInt8}, a) == x
         @test convert(CategoricalVector{Float32, UInt8}, a) == x
 
-        @test CategoricalArray{Float64}(a, ordered=isordered) == x
-        @test CategoricalArray{Float32}(a, ordered=isordered) == x
-        @test CategoricalArray{Float64, 1}(a, ordered=isordered) == x
-        @test CategoricalArray{Float32, 1}(a, ordered=isordered) == x
-        @test CategoricalArray{Float64, 1, R}(a, ordered=isordered) == x
-        @test CategoricalArray{Float32, 1, R}(a, ordered=isordered) == x
-        @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=isordered) == x
+        @test CategoricalArray{Float64}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
+        @test CategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
 
-        @test CategoricalVector(a, ordered=isordered) == x
-        @test CategoricalVector{Float64}(a, ordered=isordered) == x
-        @test CategoricalVector{Float32}(a, ordered=isordered) == x
-        @test CategoricalVector{Float64, R}(a, ordered=isordered) == x
-        @test CategoricalVector{Float32, R}(a, ordered=isordered) == x
-        @test CategoricalVector{Float64, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalVector{Float32, DefaultRefType}(a, ordered=isordered) == x
+        @test CategoricalVector(a, ordered=ordered) == x
+        @test CategoricalVector{Float64}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, R}(a, ordered=ordered) == x
+        @test CategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
 
         for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                      (a, DefaultRefType, DefaultRefType, false),
                                      (x, R, UInt8, true),
                                      (x, R, R, false))
-            x2 = categorical(y, ordered=isordered)
+            x2 = categorical(y, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{Float64, R1})
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
 
-            x2 = categorical(y, compact, ordered=isordered)
+            x2 = categorical(y, compact, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalVector{Float64, R2})
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
         end
 
         x2 = copy(x)
         @test x2 == x
         @test typeof(x2) === typeof(x)
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test levels(x2) == levels(x)
 
         @test x[1] === x.pool.valindex[1]
@@ -334,40 +334,40 @@ for isordered in (false, true)
         push!(x, 2.0)
         @test length(x) == 5
         @test x[end] == 2.0
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         push!(x, x[1])
         @test length(x) == 6
         @test x[1] == x[end]
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         append!(x, x)
         @test length(x) == 12
         @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         b = [2.5, 3.0, -3.5]
-        y = CategoricalVector{Float64, R}(b, ordered=isordered)
+        y = CategoricalVector{Float64, R}(b, ordered=ordered)
         append!(x, y)
         @test length(x) == 15
         @test x == [-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
 
         empty!(x)
         @test length(x) == 0
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
 
         # Matrix
         a = ["a" "b" "c"; "b" "a" "c"]
-        x = CategoricalMatrix{String, R}(a, ordered=isordered)
+        x = CategoricalMatrix{String, R}(a, ordered=ordered)
 
         @test x == a
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == unique(a)
         @test size(x) === (2, 3)
         @test length(x) === 6
@@ -385,22 +385,22 @@ for isordered in (false, true)
         @test convert(CategoricalMatrix{String, DefaultRefType}, x) == x
         @test convert(CategoricalMatrix{String, UInt8}, x) == x
 
-        for y in (CategoricalArray(x, ordered=isordered),
-                  CategoricalArray{String}(x, ordered=isordered),
-                  CategoricalArray{String, 2}(x, ordered=isordered),
-                  CategoricalArray{String, 2, R}(x, ordered=isordered),
-                  CategoricalArray{String, 2, DefaultRefType}(x, ordered=isordered),
-                  CategoricalArray{String, 2, UInt8}(x, ordered=isordered),
-                  CategoricalMatrix(x, ordered=isordered),
-                  CategoricalMatrix{String}(x, ordered=isordered),
-                  CategoricalMatrix{String, R}(x, ordered=isordered),
-                  CategoricalMatrix{String, DefaultRefType}(x, ordered=isordered),
-                  CategoricalMatrix{String, UInt8}(x, ordered=isordered),
-                  categorical(x, ordered=isordered),
-                  categorical(x, false, ordered=isordered),
-                  categorical(x, true, ordered=isordered))
+        for y in (CategoricalArray(x, ordered=ordered),
+                  CategoricalArray{String}(x, ordered=ordered),
+                  CategoricalArray{String, 2}(x, ordered=ordered),
+                  CategoricalArray{String, 2, R}(x, ordered=ordered),
+                  CategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
+                  CategoricalArray{String, 2, UInt8}(x, ordered=ordered),
+                  CategoricalMatrix(x, ordered=ordered),
+                  CategoricalMatrix{String}(x, ordered=ordered),
+                  CategoricalMatrix{String, R}(x, ordered=ordered),
+                  CategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
+                  CategoricalMatrix{String, UInt8}(x, ordered=ordered),
+                  categorical(x, ordered=ordered),
+                  categorical(x, false, ordered=ordered),
+                  categorical(x, true, ordered=ordered))
             @test isa(y, CategoricalMatrix{String})
-            @test ordered(y) === isordered
+            @test isordered(y) === ordered
             @test y == x
             @test y !== x
             @test y.refs !== x.refs
@@ -419,44 +419,44 @@ for isordered in (false, true)
         @test convert(CategoricalMatrix{String, DefaultRefType}, a) == x
         @test convert(CategoricalMatrix{String, UInt8}, a) == x
 
-        @test CategoricalArray{String}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 2}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 2}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 2, R}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalArray{String, 2, UInt8}(a, ordered=isordered) == x
+        @test CategoricalArray{String}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, R}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
 
-        @test CategoricalMatrix(a, ordered=isordered) == x
-        @test CategoricalMatrix{String}(a, ordered=isordered) == x
-        @test CategoricalMatrix{String, R}(a, ordered=isordered) == x
-        @test CategoricalMatrix{String, DefaultRefType}(a, ordered=isordered) == x
-        @test CategoricalMatrix{String, UInt8}(a, ordered=isordered) == x
+        @test CategoricalMatrix(a, ordered=ordered) == x
+        @test CategoricalMatrix{String}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, R}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+        @test CategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
 
         for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                      (a, DefaultRefType, DefaultRefType, false),
                                      (x, R, UInt8, true),
                                      (x, R, R, false))
-            x2 = categorical(y, ordered=isordered)
+            x2 = categorical(y, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalMatrix{String, R1})
-            @test ordered(x2) === isordered
-            
-            x2 = categorical(y, compact, ordered=isordered)
+            @test isordered(x2) === ordered
+
+            x2 = categorical(y, compact, ordered=ordered)
             @test x2 == x
             @test isa(x2, CategoricalMatrix{String, R2})
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
         end
 
         x2 = compact(x)
         @test x2 == x
         @test isa(x2, CategoricalMatrix{String, UInt8})
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test levels(x2) == levels(x)
 
         x2 = copy(x)
         @test x2 == x
         @test typeof(x2) === typeof(x)
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test levels(x2) == levels(x)
 
         @test x[1] === x.pool.valindex[1]
@@ -511,27 +511,27 @@ for isordered in (false, true)
 
 
         # Uninitialized array
-        v = Any[CategoricalArray(2, ordered=isordered),
-                CategoricalArray(String, 2, ordered=isordered),
-                CategoricalArray{String}(2, ordered=isordered),
-                CategoricalArray{String, 1}(2, ordered=isordered),
-                CategoricalArray{String, 1, R}(2, ordered=isordered),
-                CategoricalVector{String}(2, ordered=isordered),
-                CategoricalVector{String, R}(2, ordered=isordered),
-                CategoricalArray(2, 3, ordered=isordered),
-                CategoricalArray(String, 2, 3, ordered=isordered),
-                CategoricalArray{String}(2, 3, ordered=isordered),
-                CategoricalArray{String, 2}(2, 3, ordered=isordered),
-                CategoricalArray{String, 2, R}(2, 3, ordered=isordered),
-                CategoricalMatrix{String}(2, 3, ordered=isordered),
-                CategoricalMatrix{String, R}(2, 3, ordered=isordered)]
+        v = Any[CategoricalArray(2, ordered=ordered),
+                CategoricalArray(String, 2, ordered=ordered),
+                CategoricalArray{String}(2, ordered=ordered),
+                CategoricalArray{String, 1}(2, ordered=ordered),
+                CategoricalArray{String, 1, R}(2, ordered=ordered),
+                CategoricalVector{String}(2, ordered=ordered),
+                CategoricalVector{String, R}(2, ordered=ordered),
+                CategoricalArray(2, 3, ordered=ordered),
+                CategoricalArray(String, 2, 3, ordered=ordered),
+                CategoricalArray{String}(2, 3, ordered=ordered),
+                CategoricalArray{String, 2}(2, 3, ordered=ordered),
+                CategoricalArray{String, 2, R}(2, 3, ordered=ordered),
+                CategoricalMatrix{String}(2, 3, ordered=ordered),
+                CategoricalMatrix{String, R}(2, 3, ordered=ordered)]
 
         # See conditional definition of constructors in array.jl
         if VERSION >= v"0.5.0-dev"
-            push!(v, CategoricalVector(2, ordered=isordered),
-                     CategoricalVector(String, 2, ordered=isordered),
-                     CategoricalMatrix(2, 3, ordered=isordered),
-                     CategoricalMatrix(String, 2, 3, ordered=isordered))
+            push!(v, CategoricalVector(2, ordered=ordered),
+                     CategoricalVector(String, 2, ordered=ordered),
+                     CategoricalMatrix(2, 3, ordered=ordered),
+                     CategoricalMatrix(String, 2, 3, ordered=ordered))
         end
 
         for x in v
@@ -539,7 +539,7 @@ for isordered in (false, true)
             @test !isassigned(x, 2) && isdefined(x, 2)
             @test_throws UndefRefError x[1]
             @test_throws UndefRefError x[2]
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test levels(x) == []
 
             x2 = compact(x)
@@ -564,7 +564,7 @@ for isordered in (false, true)
             @test x[1] === x.pool.valindex[2]
             @test !isassigned(x, 2) && isdefined(x, 2)
             @test_throws UndefRefError x[2]
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test levels(x) == ["c", "a"]
 
             x[2] = "c"

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -107,12 +107,13 @@ for ordered in (false, true)
         @test levels(x2) == levels(x)
 
         if !isordered(x)
-            @test ordered!(x, true) === true
+            @test ordered!(x, true) === x
+            @test isordered(x) === true
         end
         @test x[1] > x[2]
         @test x[3] > x[2]
 
-        @test ordered!(x, false) === false
+        @test ordered!(x, false) === x
         @test isordered(x) === false
         @test_throws Exception x[1] > x[2]
         @test_throws Exception x[3] > x[2]

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -143,13 +143,15 @@ for ordered in (false, true)
         @test x[3] === x.pool.valindex[1]
         @test levels(x) == ["a", "b", "c"]
 
-        droplevels!(x) == ["a", "b"]
+        @test droplevels!(x) === x
+        @test levels(x) == ["a", "b"]
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[2]
         @test levels(x) == ["a", "b"]
 
-        levels!(x, ["b", "a"]) == ["b", "a"]
+        @test levels!(x, ["b", "a"]) === x
+        @test levels(x) == ["b", "a"]
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[2]
@@ -159,7 +161,8 @@ for ordered in (false, true)
         @test_throws ArgumentError levels!(x, ["e", "b"])
         @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
 
-        @test levels!(x, ["e", "a", "b"]) == ["e", "a", "b"]
+        @test levels!(x, ["e", "a", "b"]) === x
+        @test levels(x) == ["e", "a", "b"]
         @test x[1] === x.pool.valindex[1]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[2]

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -158,13 +158,15 @@ for ordered in (false, true)
             @test x[3] === Nullable(x.pool.valindex[1])
             @test levels(x) == ["a", "b", "c"]
 
-            droplevels!(x) == ["a", "b"]
+            @test droplevels!(x) === x
+            @test levels(x) == ["a", "b"]
             @test x[1] === Nullable(x.pool.valindex[1])
             @test x[2] === Nullable(x.pool.valindex[2])
             @test x[3] === Nullable(x.pool.valindex[2])
             @test levels(x) == ["a", "b"]
 
-            levels!(x, ["b", "a"]) == ["b", "a"]
+            @test levels!(x, ["b", "a"]) === x
+            @test levels(x) == ["b", "a"]
             @test x[1] === Nullable(x.pool.valindex[1])
             @test x[2] === Nullable(x.pool.valindex[2])
             @test x[3] === Nullable(x.pool.valindex[2])
@@ -174,7 +176,8 @@ for ordered in (false, true)
             @test_throws ArgumentError levels!(x, ["e", "b"])
             @test_throws ArgumentError levels!(x, ["e", "a", "b", "a"])
 
-            @test levels!(x, ["e", "a", "b"]) == ["e", "a", "b"]
+            @test levels!(x, ["e", "a", "b"]) === x
+            @test levels(x) == ["e", "a", "b"]
             @test x[1] === Nullable(x.pool.valindex[1])
             @test x[2] === Nullable(x.pool.valindex[2])
             @test x[3] === Nullable(x.pool.valindex[2])
@@ -187,7 +190,8 @@ for ordered in (false, true)
             @test levels(x) == ["e", "a", "b", "c"]
 
             @test_throws ArgumentError levels!(x, ["e", "c"])
-            @test levels!(x, ["e", "c"], nullok=true) == ["e", "c"]
+            @test levels!(x, ["e", "c"], nullok=true) === x
+            @test levels(x) == ["e", "c"]
             @test x[1] === Nullable(x.pool.valindex[2])
             @test x[2] === eltype(x)()
             @test x[3] === eltype(x)()

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -11,17 +11,17 @@ typealias String Compat.ASCIIString
 # == currently throws an error for Nullables
 (==) = isequal
 
-for isordered in (false, true)
+for ordered in (false, true)
     for R in (CategoricalArrays.DefaultRefType, UInt8, UInt, Int8, Int)
         # Vector with no null values
         for a in (["b", "a", "b"],
                   Nullable{String}["b", "a", "b"],
                   NullableArray(["b", "a", "b"]))
-            x = NullableCategoricalVector{String, R}(a, ordered=isordered)
+            x = NullableCategoricalVector{String, R}(a, ordered=ordered)
             na = eltype(a) <: Nullable ? a : convert(Array{Nullable{String}}, a)
 
             @test x == na
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test levels(x) == sort(map(get, unique(na)))
             @test size(x) === (3,)
             @test length(x) === 3
@@ -39,22 +39,22 @@ for isordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalVector{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=isordered),
-                      NullableCategoricalArray{String}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, R}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=isordered),
-                      NullableCategoricalVector(x, ordered=isordered),
-                      NullableCategoricalVector{String}(x, ordered=isordered),
-                      NullableCategoricalVector{String, R}(x, ordered=isordered),
-                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalVector{String, UInt8}(x, ordered=isordered),
-                      categorical(x, ordered=isordered),
-                      categorical(x, false, ordered=isordered),
-                      categorical(x, true, ordered=isordered))
+            for y in (NullableCategoricalArray(x, ordered=ordered),
+                      NullableCategoricalArray{String}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, R}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=ordered),
+                      NullableCategoricalVector(x, ordered=ordered),
+                      NullableCategoricalVector{String}(x, ordered=ordered),
+                      NullableCategoricalVector{String, R}(x, ordered=ordered),
+                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalVector{String, UInt8}(x, ordered=ordered),
+                      categorical(x, ordered=ordered),
+                      categorical(x, false, ordered=ordered),
+                      categorical(x, true, ordered=ordered))
                 @test isa(y, NullableCategoricalVector{String})
-                @test ordered(y) === isordered
+                @test isordered(y) === ordered
                 @test y == x
                 @test y !== x
                 @test y.refs !== x.refs
@@ -74,61 +74,61 @@ for isordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, a) == x
             @test convert(NullableCategoricalVector{String, UInt8}, a) == x
 
-            @test NullableCategoricalArray{String}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, R}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalArray{String}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, R}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, UInt8}(a, ordered=ordered) == x
 
-            @test NullableCategoricalVector(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, R}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalVector(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, R}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, UInt8}(a, ordered=ordered) == x
 
             for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                          (a, DefaultRefType, DefaultRefType, false),
                                          (x, R, UInt8, true),
                                          (x, R, R, false))
-                x2 = categorical(y, ordered=isordered)
+                x2 = categorical(y, ordered=ordered)
                 @test x2 == y
                 if eltype(y) <: Nullable
                     @test isa(x2, NullableCategoricalVector{String, R1})
                 else
                     @test isa(x2, CategoricalVector{String, R1})
                 end
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
 
-                x2 = categorical(y, compact, ordered=isordered)
+                x2 = categorical(y, compact, ordered=ordered)
                 @test x2 == y
                 if eltype(y) <: Nullable
                     @test isa(x2, NullableCategoricalVector{String, R2})
                 else
                     @test isa(x2, CategoricalVector{String, R2})
                 end
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
             end
 
             x2 = compact(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalVector{String, UInt8})
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             x2 = copy(x)
             @test x2 == x
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test typeof(x2) === typeof(x)
             @test levels(x2) == levels(x)
 
-            if !ordered(x)
+            if !isordered(x)
                 @test ordered!(x, true) === true
             end
             @test get(x[1] > x[2])
             @test get(x[3] > x[2])
 
             @test ordered!(x, false) === false
-            @test ordered(x) === false
+            @test isordered(x) === false
             @test_throws Exception x[1] > x[2]
             @test_throws Exception x[3] > x[2]
 
@@ -216,19 +216,19 @@ for isordered in (false, true)
             append!(x, x)
             @test isequal(x, NullableArray(["c", "", "", "e", "zz", "c", "", "c", "", "", "e", "zz", "c", ""], [false, true, true, false, false, false, true, false, true, true, false, false, false, true]))
             @test levels(x) == ["e", "c", "zz"]
-            @test ordered(x) === false
+            @test isordered(x) === false
             @test length(x) == 14
 
             b = ["z","y","x"]
             y = NullableCategoricalVector{String, R}(b)
             append!(x, y)
             @test length(x) == 17
-            @test ordered(x) === false
+            @test isordered(x) === false
             @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
             @test isequal(x, NullableArray(["c", "", "", "e", "zz", "c", "", "c", "", "", "e", "zz", "c", "", "z", "y", "x"], [false, true, true, false, false, false, true, false, true, true, false, false, false, true, false, false, false]))
 
             empty!(x)
-            @test ordered(x) === false
+            @test isordered(x) === false
             @test length(x) == 0
             @test levels(x) == ["e", "c", "zz", "x", "y", "z"]
         end
@@ -237,7 +237,7 @@ for isordered in (false, true)
         # Vector with null values
         for a in (Nullable{String}["a", "b", Nullable()],
                   NullableArray(Nullable{String}["a", "b", Nullable()]))
-            x = NullableCategoricalVector{String, R}(a, ordered=isordered)
+            x = NullableCategoricalVector{String, R}(a, ordered=ordered)
 
             @test x == a
             @test levels(x) == map(get, filter(x->!isnull(x), unique(a)))
@@ -257,22 +257,22 @@ for isordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalVector{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=isordered),
-                      NullableCategoricalArray{String}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, R}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=isordered),
-                      NullableCategoricalVector(x, ordered=isordered),
-                      NullableCategoricalVector{String}(x, ordered=isordered),
-                      NullableCategoricalVector{String, R}(x, ordered=isordered),
-                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalVector{String, UInt8}(x, ordered=isordered),
-                      categorical(x, ordered=isordered),
-                      categorical(x, false, ordered=isordered),
-                      categorical(x, true, ordered=isordered))
+            for y in (NullableCategoricalArray(x, ordered=ordered),
+                      NullableCategoricalArray{String}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, R}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 1, UInt8}(x, ordered=ordered),
+                      NullableCategoricalVector(x, ordered=ordered),
+                      NullableCategoricalVector{String}(x, ordered=ordered),
+                      NullableCategoricalVector{String, R}(x, ordered=ordered),
+                      NullableCategoricalVector{String, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalVector{String, UInt8}(x, ordered=ordered),
+                      categorical(x, ordered=ordered),
+                      categorical(x, false, ordered=ordered),
+                      categorical(x, true, ordered=ordered))
                 @test isa(y, NullableCategoricalVector{String})
-                @test ordered(y) === isordered
+                @test isordered(y) === ordered
                 @test y == x
                 @test y !== x
                 @test y.refs !== x.refs
@@ -292,31 +292,31 @@ for isordered in (false, true)
             @test convert(NullableCategoricalVector{String, DefaultRefType}, a) == x
             @test convert(NullableCategoricalVector{String, UInt8}, a) == x
 
-            @test NullableCategoricalArray{String}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, R}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 1, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalArray{String}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, R}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 1, UInt8}(a, ordered=ordered) == x
 
-            @test NullableCategoricalVector(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, R}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalVector{String, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalVector(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, R}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalVector{String, UInt8}(a, ordered=ordered) == x
 
             for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                          (a, DefaultRefType, DefaultRefType, false),
                                          (x, R, UInt8, true),
                                          (x, R, R, false))
-                x2 = categorical(y, ordered=isordered)
+                x2 = categorical(y, ordered=ordered)
                 @test x2 == y
                 @test isa(x2, NullableCategoricalVector{String, R1})
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
 
-                x2 = categorical(y, compact, ordered=isordered)
+                x2 = categorical(y, compact, ordered=ordered)
                 @test x2 == y
                 @test isa(x2, NullableCategoricalVector{String, R2})
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
             end
 
             x2 = compact(x)
@@ -368,10 +368,10 @@ for isordered in (false, true)
         # Vector created from range (i.e. non-Array AbstractArray),
         # direct conversion to a vector with different eltype
         a = 0.0:0.5:1.5
-        x = NullableCategoricalVector{Float64, R}(a, ordered=isordered)
+        x = NullableCategoricalVector{Float64, R}(a, ordered=ordered)
 
         @test x == map(Nullable, a)
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == unique(a)
         @test size(x) === (4,)
         @test length(x) === 4
@@ -389,22 +389,22 @@ for isordered in (false, true)
         @test convert(NullableCategoricalVector{Float64, DefaultRefType}, x) == x
         @test convert(NullableCategoricalVector{Float64, UInt8}, x) == x
 
-        for y in (NullableCategoricalArray(x, ordered=isordered),
-                  NullableCategoricalArray{Float64}(x, ordered=isordered),
-                  NullableCategoricalArray{Float64, 1}(x, ordered=isordered),
-                  NullableCategoricalArray{Float64, 1, R}(x, ordered=isordered),
-                  NullableCategoricalArray{Float64, 1, DefaultRefType}(x, ordered=isordered),
-                  NullableCategoricalArray{Float64, 1, UInt8}(x, ordered=isordered),
-                  NullableCategoricalVector(x, ordered=isordered),
-                  NullableCategoricalVector{Float64}(x, ordered=isordered),
-                  NullableCategoricalVector{Float64, R}(x, ordered=isordered),
-                  NullableCategoricalVector{Float64, DefaultRefType}(x, ordered=isordered),
-                  NullableCategoricalVector{Float64, UInt8}(x, ordered=isordered),
-                  categorical(x, ordered=isordered),
-                  categorical(x, false, ordered=isordered),
-                  categorical(x, true, ordered=isordered))
+        for y in (NullableCategoricalArray(x, ordered=ordered),
+                  NullableCategoricalArray{Float64}(x, ordered=ordered),
+                  NullableCategoricalArray{Float64, 1}(x, ordered=ordered),
+                  NullableCategoricalArray{Float64, 1, R}(x, ordered=ordered),
+                  NullableCategoricalArray{Float64, 1, DefaultRefType}(x, ordered=ordered),
+                  NullableCategoricalArray{Float64, 1, UInt8}(x, ordered=ordered),
+                  NullableCategoricalVector(x, ordered=ordered),
+                  NullableCategoricalVector{Float64}(x, ordered=ordered),
+                  NullableCategoricalVector{Float64, R}(x, ordered=ordered),
+                  NullableCategoricalVector{Float64, DefaultRefType}(x, ordered=ordered),
+                  NullableCategoricalVector{Float64, UInt8}(x, ordered=ordered),
+                  categorical(x, ordered=ordered),
+                  categorical(x, false, ordered=ordered),
+                  categorical(x, true, ordered=ordered))
             @test isa(y, NullableCategoricalVector{Float64})
-            @test ordered(y) === isordered
+            @test isordered(y) === ordered
             @test y == x
             @test y !== x
             @test y.refs !== x.refs
@@ -433,55 +433,55 @@ for isordered in (false, true)
         @test convert(NullableCategoricalVector{Float64, UInt8}, a) == x
         @test convert(NullableCategoricalVector{Float32, UInt8}, a) == x
 
-        @test NullableCategoricalArray{Float64}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float32}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float64, 1}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float32, 1}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float64, 1, R}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float32, 1, R}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float64, 1, DefaultRefType}(a, ordered=isordered) == x
-        @test NullableCategoricalArray{Float32, 1, DefaultRefType}(a, ordered=isordered) == x
+        @test NullableCategoricalArray{Float64}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float32}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float64, 1}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float32, 1}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float64, 1, R}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float32, 1, R}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float64, 1, DefaultRefType}(a, ordered=ordered) == x
+        @test NullableCategoricalArray{Float32, 1, DefaultRefType}(a, ordered=ordered) == x
 
-        @test NullableCategoricalVector(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float64}(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float32}(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float64, R}(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float32, R}(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float64, DefaultRefType}(a, ordered=isordered) == x
-        @test NullableCategoricalVector{Float32, DefaultRefType}(a, ordered=isordered) == x
+        @test NullableCategoricalVector(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float64}(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float32}(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float64, R}(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float32, R}(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float64, DefaultRefType}(a, ordered=ordered) == x
+        @test NullableCategoricalVector{Float32, DefaultRefType}(a, ordered=ordered) == x
 
         for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                      (a, DefaultRefType, DefaultRefType, false),
                                      (x, R, UInt8, true),
                                      (x, R, R, false))
-            x2 = categorical(y, ordered=isordered)
+            x2 = categorical(y, ordered=ordered)
             @test x2 == collect(y)
             if eltype(y) <: Nullable
                 @test isa(x2, NullableCategoricalVector{Float64, R1})
             else
                 @test isa(x2, CategoricalVector{Float64, R1})
             end
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
 
-            x2 = categorical(y, compact, ordered=isordered)
+            x2 = categorical(y, compact, ordered=ordered)
             @test x2 == collect(y)
             if eltype(y) <: Nullable
                 @test isa(x2, NullableCategoricalVector{Float64, R2})
             else
                 @test isa(x2, CategoricalVector{Float64, R2})
             end
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
         end
 
         x2 = compact(x)
         @test x2 == x
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test isa(x2, NullableCategoricalVector{Float64, UInt8})
         @test levels(x2) == levels(x)
 
         x2 = copy(x)
         @test x2 == x
-        @test ordered(x2) === ordered(x)
+        @test isordered(x2) === isordered(x)
         @test typeof(x2) === typeof(x)
         @test levels(x2) == levels(x)
 
@@ -511,19 +511,19 @@ for isordered in (false, true)
         push!(x, 2.0)
         @test length(x) == 5
         @test isequal(x, NullableArray([-1.0, -1.0, 1.0, 1.5, 2.0]))
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         push!(x, x[1])
         @test length(x) == 6
         @test isequal(x, NullableArray([-1.0, -1.0, 1.0, 1.5, 2.0, -1.0]))
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         append!(x, x)
         @test length(x) == 12
         @test isequal(x, NullableArray([-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0]))
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0,  0.5,  1.0,  1.5, -1.0,  2.0]
 
         b = [2.5, 3.0, -3.5]
@@ -531,12 +531,12 @@ for isordered in (false, true)
         append!(x, y)
         @test length(x) == 15
         @test isequal(x, NullableArray([-1.0, -1.0, 1.0, 1.5, 2.0, -1.0, -1.0, -1.0, 1.0, 1.5, 2.0, -1.0, 2.5, 3.0, -3.5]))
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
 
         empty!(x)
         @test length(x) == 0
-        @test ordered(x) === isordered
+        @test isordered(x) === ordered
         @test levels(x) == [0.0, 0.5, 1.0, 1.5, -1.0, 2.0, -3.5, 2.5, 3.0]
 
         # Matrix with no null values
@@ -544,10 +544,10 @@ for isordered in (false, true)
                   Nullable{String}["a" "b" "c"; "b" "a" "c"],
                   NullableArray(["a" "b" "c"; "b" "a" "c"]))
             na = eltype(a) <: Nullable ? a : convert(Array{Nullable{String}}, a)
-            x = NullableCategoricalMatrix{String, R}(a, ordered=isordered)
+            x = NullableCategoricalMatrix{String, R}(a, ordered=ordered)
 
             @test x == na
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test levels(x) == map(get, unique(na))
             @test size(x) === (2, 3)
             @test length(x) === 6
@@ -565,22 +565,22 @@ for isordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=isordered),
-                      NullableCategoricalArray{String}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, R}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=isordered),
-                      NullableCategoricalMatrix(x, ordered=isordered),
-                      NullableCategoricalMatrix{String}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, R}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, UInt8}(x, ordered=isordered),
-                      categorical(x, ordered=isordered),
-                      categorical(x, false, ordered=isordered),
-                      categorical(x, true, ordered=isordered))
+            for y in (NullableCategoricalArray(x, ordered=ordered),
+                      NullableCategoricalArray{String}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, R}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=ordered),
+                      NullableCategoricalMatrix(x, ordered=ordered),
+                      NullableCategoricalMatrix{String}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, R}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, UInt8}(x, ordered=ordered),
+                      categorical(x, ordered=ordered),
+                      categorical(x, false, ordered=ordered),
+                      categorical(x, true, ordered=ordered))
                 @test isa(y, NullableCategoricalMatrix{String})
-                @test ordered(y) === isordered
+                @test isordered(y) === ordered
                 @test y == x
                 @test y !== x
                 @test y.refs !== x.refs
@@ -599,52 +599,52 @@ for isordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, a) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, a) == x
 
-            @test NullableCategoricalArray{String}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, R}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalArray{String}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, R}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
 
-            @test NullableCategoricalMatrix(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, R}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalMatrix(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, R}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
 
             for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                          (a, DefaultRefType, DefaultRefType, false),
                                          (x, R, UInt8, true),
                                          (x, R, R, false))
-            x2 = categorical(y, ordered=isordered)
+            x2 = categorical(y, ordered=ordered)
             @test x2 == y
             if eltype(y) <: Nullable
                 @test isa(x2, NullableCategoricalMatrix{String, R1})
             else
                 @test isa(x2, CategoricalMatrix{String, R1})
             end
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
 
-            x2 = categorical(y, compact, ordered=isordered)
+            x2 = categorical(y, compact, ordered=ordered)
             @test x2 == y
             if eltype(y) <: Nullable
                 @test isa(x2, NullableCategoricalMatrix{String, R2})
             else
                 @test isa(x2, CategoricalMatrix{String, R2})
             end
-            @test ordered(x2) === isordered
+            @test isordered(x2) === ordered
             end
 
             x2 = compact(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalMatrix{String, UInt8})
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             x2 = copy(x)
             @test x2 == x
             @test typeof(x2) === typeof(x)
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             @test x[1] === Nullable(x.pool.valindex[1])
@@ -702,10 +702,10 @@ for isordered in (false, true)
         # Matrix with null values
         for a in (Nullable{String}["a" Nullable() "c"; "b" "a" Nullable()],
                   NullableArray(Nullable{String}["a" Nullable() "c"; "b" "a" Nullable()]))
-            x = NullableCategoricalMatrix{String, R}(a, ordered=isordered)
+            x = NullableCategoricalMatrix{String, R}(a, ordered=ordered)
 
             @test x == a
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test levels(x) == map(get, filter(x->!isnull(x), unique(a)))
             @test size(x) === (2, 3)
             @test length(x) === 6
@@ -723,22 +723,22 @@ for isordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, x) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, x) == x
 
-            for y in (NullableCategoricalArray(x, ordered=isordered),
-                      NullableCategoricalArray{String}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, R}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=isordered),
-                      NullableCategoricalMatrix(x, ordered=isordered),
-                      NullableCategoricalMatrix{String}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, R}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=isordered),
-                      NullableCategoricalMatrix{String, UInt8}(x, ordered=isordered),
-                      categorical(x, ordered=isordered),
-                      categorical(x, false, ordered=isordered),
-                      categorical(x, true, ordered=isordered))
+            for y in (NullableCategoricalArray(x, ordered=ordered),
+                      NullableCategoricalArray{String}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, R}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalArray{String, 2, UInt8}(x, ordered=ordered),
+                      NullableCategoricalMatrix(x, ordered=ordered),
+                      NullableCategoricalMatrix{String}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, R}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, DefaultRefType}(x, ordered=ordered),
+                      NullableCategoricalMatrix{String, UInt8}(x, ordered=ordered),
+                      categorical(x, ordered=ordered),
+                      categorical(x, false, ordered=ordered),
+                      categorical(x, true, ordered=ordered))
                 @test isa(y, NullableCategoricalMatrix{String})
-                @test ordered(y) === isordered
+                @test isordered(y) === ordered
                 @test y == x
                 @test y !== x
                 @test y.refs !== x.refs
@@ -757,44 +757,44 @@ for isordered in (false, true)
             @test convert(NullableCategoricalMatrix{String, DefaultRefType}, a) == x
             @test convert(NullableCategoricalMatrix{String, UInt8}, a) == x
 
-            @test NullableCategoricalArray{String}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, R}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalArray{String, 2, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalArray{String}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, R}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalArray{String, 2, UInt8}(a, ordered=ordered) == x
 
-            @test NullableCategoricalMatrix(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, R}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, DefaultRefType}(a, ordered=isordered) == x
-            @test NullableCategoricalMatrix{String, UInt8}(a, ordered=isordered) == x
+            @test NullableCategoricalMatrix(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, R}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, DefaultRefType}(a, ordered=ordered) == x
+            @test NullableCategoricalMatrix{String, UInt8}(a, ordered=ordered) == x
 
             for (y, R1, R2, compact) in ((a, DefaultRefType, UInt8, true),
                                          (a, DefaultRefType, DefaultRefType, false),
                                          (x, R, UInt8, true),
                                          (x, R, R, false))
-                x2 = categorical(y, ordered=isordered)
+                x2 = categorical(y, ordered=ordered)
                 @test x2 == y
                 @test isa(x2, NullableCategoricalMatrix{String, R1})
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
 
-                x2 = categorical(y, compact, ordered=isordered)
+                x2 = categorical(y, compact, ordered=ordered)
                 @test x2 == y
                 @test isa(x2, NullableCategoricalMatrix{String, R2})
-                @test ordered(x2) === isordered
+                @test isordered(x2) === ordered
             end
 
             x2 = compact(x)
             @test x2 == x
             @test isa(x2, NullableCategoricalMatrix{String, UInt8})
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             x2 = copy(x)
             @test x2 == x
             @test typeof(x2) === typeof(x)
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == levels(x)
 
             @test x[1] === Nullable(x.pool.valindex[1])
@@ -876,52 +876,52 @@ for isordered in (false, true)
 
 
             # Constructor with values plus missingness array
-            x = NullableCategoricalArray(1:3, [true, false, true], ordered=isordered)
+            x = NullableCategoricalArray(1:3, [true, false, true], ordered=ordered)
             @test x == Nullable{Int}[Nullable(), 2, Nullable()]
-            @test ordered(x) == isordered
+            @test isordered(x) == ordered
             @test levels(x) == [2]
 
             if VERSION >= v"0.5.0-dev"
-                x = NullableCategoricalVector(1:3, [true, false, true], ordered=isordered)
+                x = NullableCategoricalVector(1:3, [true, false, true], ordered=ordered)
                 @test x == Nullable{Int}[Nullable(), 2, Nullable()]
-                @test ordered(x) === isordered
+                @test isordered(x) === ordered
                 @test levels(x) == [2]
 
                 x = NullableCategoricalMatrix([1 2; 3 4], [true false; false true],
-                                              ordered=isordered)
+                                              ordered=ordered)
                 @test x == Nullable{Int}[Nullable() 2; 3 Nullable()]
-                @test ordered(x) === isordered
+                @test isordered(x) === ordered
                 @test levels(x) == [2, 3]
             end
         end
 
 
         # Uninitialized array
-        v = Any[NullableCategoricalArray(2, ordered=isordered),
-                NullableCategoricalArray(String, 2, ordered=isordered),
-                NullableCategoricalArray{String}(2, ordered=isordered),
-                NullableCategoricalArray{String, 1}(2, ordered=isordered),
-                NullableCategoricalArray{String, 1, R}(2, ordered=isordered),
-                NullableCategoricalVector{String}(2, ordered=isordered),
-                NullableCategoricalVector{String, R}(2, ordered=isordered),
-                NullableCategoricalArray(2, 3, ordered=isordered),
-                NullableCategoricalArray(String, 2, 3, ordered=isordered),
-                NullableCategoricalArray{String}(2, 3, ordered=isordered),
-                NullableCategoricalArray{String, 2}(2, 3, ordered=isordered),
-                NullableCategoricalArray{String, 2, R}(2, 3, ordered=isordered),
-                NullableCategoricalMatrix{String}(2, 3, ordered=isordered),
-                NullableCategoricalMatrix{String, R}(2, 3, ordered=isordered)]
+        v = Any[NullableCategoricalArray(2, ordered=ordered),
+                NullableCategoricalArray(String, 2, ordered=ordered),
+                NullableCategoricalArray{String}(2, ordered=ordered),
+                NullableCategoricalArray{String, 1}(2, ordered=ordered),
+                NullableCategoricalArray{String, 1, R}(2, ordered=ordered),
+                NullableCategoricalVector{String}(2, ordered=ordered),
+                NullableCategoricalVector{String, R}(2, ordered=ordered),
+                NullableCategoricalArray(2, 3, ordered=ordered),
+                NullableCategoricalArray(String, 2, 3, ordered=ordered),
+                NullableCategoricalArray{String}(2, 3, ordered=ordered),
+                NullableCategoricalArray{String, 2}(2, 3, ordered=ordered),
+                NullableCategoricalArray{String, 2, R}(2, 3, ordered=ordered),
+                NullableCategoricalMatrix{String}(2, 3, ordered=ordered),
+                NullableCategoricalMatrix{String, R}(2, 3, ordered=ordered)]
 
         # See conditional definition of constructors in array.jl and nullablearray.jl
         if VERSION >= v"0.5.0-dev"
-            push!(v, NullableCategoricalVector(2, ordered=isordered),
-                     NullableCategoricalVector(String, 2, ordered=isordered),
-                     NullableCategoricalMatrix(2, 3, ordered=isordered),
-                     NullableCategoricalMatrix(String, 2, 3, ordered=isordered))
+            push!(v, NullableCategoricalVector(2, ordered=ordered),
+                     NullableCategoricalVector(String, 2, ordered=ordered),
+                     NullableCategoricalMatrix(2, 3, ordered=ordered),
+                     NullableCategoricalMatrix(String, 2, 3, ordered=ordered))
         end
 
         for x in v
-            @test ordered(x) === isordered
+            @test isordered(x) === ordered
             @test isnull(x[1])
             @test isnull(x[2])
             @test levels(x) == []
@@ -933,13 +933,13 @@ for isordered in (false, true)
             else
                 @test isa(x2, NullableCategoricalArray{typeof(x).parameters[1], ndims(x), UInt8})
             end
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == []
 
             x2 = copy(x)
             @test x2 == x
             @test typeof(x2) === typeof(x)
-            @test ordered(x2) === ordered(x)
+            @test isordered(x2) === isordered(x)
             @test levels(x2) == []
 
             x[1] = "c"

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -122,12 +122,13 @@ for ordered in (false, true)
             @test levels(x2) == levels(x)
 
             if !isordered(x)
-                @test ordered!(x, true) === true
+                @test ordered!(x, true) === x
+                @test isordered(x) === true
             end
             @test get(x[1] > x[2])
             @test get(x[3] > x[2])
 
-            @test ordered!(x, false) === false
+            @test ordered!(x, false) === x
             @test isordered(x) === false
             @test_throws Exception x[1] > x[2]
             @test_throws Exception x[3] > x[2]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -55,8 +55,8 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     a2 = ["Middle", "Old"]
     ca1 = CA(a1, ordered=true)
     ca2 = CA(a2, ordered=true)
-    levels!(ca1, ["Young", "Middle"])
-    levels!(ca2, ["Middle", "Old"])
+    @test levels!(ca1, ["Young", "Middle"]) === ca1
+    @test levels!(ca2, ["Middle", "Old"]) === ca2
     r = vcat(ca1, ca2)
     @test r == A(vcat(a1, a2))
     @test levels(r) == ["Young", "Middle", "Old"]

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -32,7 +32,7 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     @test isa(cca2, CA{Int, 1, UInt8})
     @test isa(r, CA{Int, 1, CategoricalArrays.DefaultRefType})
     @test isa(vcat(cca1, ca2), CA{Int, 1, CategoricalArrays.DefaultRefType})
-    @test ordered(r) == false
+    @test isordered(r) == false
     @test levels(r) == collect(3:300)
 
     # Test vcat of multidimensional arrays
@@ -47,7 +47,7 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     r = vcat(cca1, cca2)
     @test r == A(vcat(a1, a2))
     @test isa(r, CA{Int, 4, CategoricalArrays.DefaultRefType})
-    @test ordered(r) == false
+    @test isordered(r) == false
     @test levels(r) == collect(3:length(a2)+10)
 
     # Test concatenation of mutually compatible levels
@@ -60,7 +60,7 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     r = vcat(ca1, ca2)
     @test r == A(vcat(a1, a2))
     @test levels(r) == ["Young", "Middle", "Old"]
-    @test ordered(r) == true
+    @test isordered(r) == true
 
     # Test concatenation of conflicting ordering. This drops the ordering
     a1 = ["Old", "Young", "Young"]
@@ -72,7 +72,7 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     r = vcat(ca1, ca2)
     @test r == A(vcat(a1, a2))
     @test levels(r) == ["Young", "Middle", "Old"]
-    @test ordered(r) == false
+    @test isordered(r) == false
 end
 
 end


### PR DESCRIPTION
* rename `ordered()` into `isordered()`
* `ordered!(A, x)` and `levels!(A, x)` return `A` (that also affects `droplevels!()`)

Closes #24 