### PR TITLE
Add docstrings for exported functions

### DIFF
--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -67,8 +67,15 @@ end
                                                          ordered=_isordered(A)) =
     NullableCategoricalMatrix{eltype(T)}(A, ordered=ordered)
 
+"""
+    NullableCategoricalArray(A::AbstractArray, missing::AbstractArray{Bool};
+                             ordered::Bool=false)
+
+Similar to definition above, but marks as null entries for which the corresponding entry
+in `missing` is `true`.
+"""
 function NullableCategoricalArray{T, N}(A::AbstractArray{T, N},
-                                        missing::AbstractArray{Bool};
+                                        missing::AbstractArray{Bool, N};
                                         ordered=false)
     res = NullableCategoricalArray{T, N}(size(A); ordered=ordered)
     @inbounds for (i, x, m) in zip(eachindex(res), A, missing)
@@ -83,10 +90,25 @@ function NullableCategoricalArray{T, N}(A::AbstractArray{T, N},
 end
 
 if VERSION >= v"0.5.0-dev"
+    """
+        NullableCategoricalVector(A::AbstractVector, missing::AbstractVector{Bool};
+                                  ordered::Bool=false)
+
+    Similar to definition above, but marks as null entries for which the corresponding entry
+    in `missing` is `true`.
+    """
     NullableCategoricalVector{T}(A::AbstractVector{T},
                                  missing::AbstractVector{Bool};
                                  ordered=false) =
         NullableCategoricalArray(A, missing; ordered=ordered)
+
+    """
+        NullableCategoricalMatrix(A::AbstractMatrix, missing::AbstractMatrix{Bool};
+                                  ordered::Bool=false)
+
+    Similar to definition above, but marks as null entries for which the corresponding entry
+    in `missing` is `true`.
+    """
     NullableCategoricalMatrix{T}(A::AbstractMatrix{T},
                                  missing::AbstractMatrix{Bool};
                                  ordered=false) =

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -58,4 +58,4 @@ typealias NullableCategoricalMatrix{T, R} NullableCategoricalArray{T, 2, R}
 
 ## Type Aliases
 
-typealias CatArray Union{CategoricalArray, NullableCategoricalArray}
+typealias CatArray{T, N, R} Union{CategoricalArray{T, N, R}, NullableCategoricalArray{T, N, R}}


### PR DESCRIPTION
Also move out of the eval loop some CatArray methods, as it's more
logical that way and we need to add the docstring only once.

I wouldn't mind a review, especially from a native speaker.

Cc: @alyst