### PR TITLE
delegate levels and ordered to parent of SubArray

### DIFF
--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -21,6 +21,8 @@ module CategoricalArrays
     include("nullablearray.jl")
     include("deprecated.jl")
 
+    include("subarray.jl")
+
     if VERSION < v"0.5.0-dev"
         Base.convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S, n}) = convert(Array{T, n}, x)
         Base.convert{T,n,S}(::Type{Array{T,n}}, x::AbstractArray{S,n}) = copy!(Array{T}(size(x)), x)

--- a/src/CategoricalArrays.jl
+++ b/src/CategoricalArrays.jl
@@ -19,9 +19,9 @@ module CategoricalArrays
 
     include("array.jl")
     include("nullablearray.jl")
-    include("deprecated.jl")
-
     include("subarray.jl")
+
+    include("deprecated.jl")
 
     if VERSION < v"0.5.0-dev"
         Base.convert{T,n,S}(::Type{Array{T}}, x::AbstractArray{S, n}) = convert(Array{T, n}, x)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,0 +1,7 @@
+# delegate methods for SubArrays to support view
+
+for f in [:levels, :ordered]
+    @eval begin
+        $f{T,N,P<:CatArray,I,L}(sa::SubArray{T,N,P,I,L}) = $f(parent(sa))
+    end
+end

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -2,6 +2,6 @@
 
 for f in [:levels, :isordered]
     @eval begin
-        $f{T,N,P<:CatArray,I,L}(sa::SubArray{T,N,P,I,L}) = $f(parent(sa))
+        $f{T,N,P<:CatArray}(sa::SubArray{T,N,P}) = $f(parent(sa))
     end
 end

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,6 +1,6 @@
 # delegate methods for SubArrays to support view
 
-for f in [:levels, :ordered]
+for f in [:levels, :isordered]
     @eval begin
         $f{T,N,P<:CatArray,I,L}(sa::SubArray{T,N,P,I,L}) = $f(parent(sa))
     end

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -1,0 +1,15 @@
+module TestView
+
+using Base.Test
+using CategoricalArrays
+
+for order in [true, false]
+    x = categorical(collect(1:10), ordered=order)
+    for inds in [1:2, :, 1, []]
+        v = view(x, inds)
+        @test levels(v) == levels(x)
+        @test ordered(v) == ordered(x)
+    end
+end
+
+end

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -8,7 +8,7 @@ for order in [true, false]
     for inds in [1:2, :, 1, []]
         v = view(x, inds)
         @test levels(v) == levels(x)
-        @test ordered(v) == ordered(x)
+        @test isordered(v) == isordered(x)
     end
 end
 

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -3,12 +3,14 @@ module TestView
 using Base.Test
 using CategoricalArrays
 
-for order in [true, false]
-    x = categorical(collect(1:10), ordered=order)
-    for inds in [1:2, :, 1, []]
-        v = view(x, inds)
-        @test levels(v) == levels(x)
-        @test isordered(v) == isordered(x)
+for T in [CategoricalArray, NullableCategoricalArray]
+    for order in [true, false]
+        x = T(1:10, ordered=order)
+        for inds in [1:2, :, 1, []]
+            v = view(x, inds)
+            @test levels(v) === levels(x)
+            @test isordered(v) === isordered(x)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,8 @@ module TestCategoricalArrays
         "10_isless.jl",
         "11_array.jl",
         "12_nullablearray.jl",
-        "13_arraycommon.jl"
+        "13_arraycommon.jl",
+        "14_view.jl"
     ]
 
     println("Running tests:")


### PR DESCRIPTION
Support `levels` and `ordered` for views. I didn't delegate any of the other exported functions because they're either not specific to categorical arrays or are mutating.