### PR TITLE
Add specialized unique() method for categorical arrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5.0-
 Compat 0.8.1
+NullableArrays

--- a/src/nullablearray.jl
+++ b/src/nullablearray.jl
@@ -1,4 +1,5 @@
 import Base: convert, getindex, setindex!, similar
+using NullableArrays: NullableArray
 
 ## Constructors and converters
 ## (special methods for AbstractArray{Nullable}, to avoid wrapping Nullable inside Nullable)
@@ -130,3 +131,7 @@ function setindex!(A::NullableCategoricalArray, v::Nullable, i::Int)
 end
 
 levels!(A::NullableCategoricalArray, newlevels::Vector; nullok=false) = _levels!(A, newlevels, nullok=nullok)
+
+droplevels!(A::NullableCategoricalArray) = levels!(A, _unique(Array, A.refs, A.pool))
+
+unique(A::NullableCategoricalArray) = _unique(NullableArray, A.refs, A.pool)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -5,3 +5,9 @@ for f in [:levels, :isordered]
         $f{T,N,P<:CatArray}(sa::SubArray{T,N,P}) = $f(parent(sa))
     end
 end
+
+function unique{T,N,P<:CatArray}(sa::SubArray{T,N,P})
+    A = parent(sa)
+    refs = view(A.refs, sa.indexes...)
+    _unique(eltype(P) <: Nullable ? NullableArray : Array, refs, A.pool)
+end

--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -584,4 +584,32 @@ for ordered in (false, true)
     end
 end
 
+# Test unique() and levels()
+
+x = CategoricalArray(["Old", "Young", "Middle", "Young"])
+@test levels!(x, ["Young", "Middle", "Old"]) === x
+@test levels(x) == ["Young", "Middle", "Old"]
+@test unique(x) == levels(x) == ["Young", "Middle", "Old"]
+@test levels!(x, ["Young", "Middle", "Old", "Unused"]) === x
+@test levels(x) == ["Young", "Middle", "Old", "Unused"]
+@test unique(x) == ["Young", "Middle", "Old"]
+@test levels!(x, ["Unused1", "Young", "Middle", "Old", "Unused2"]) === x
+@test levels(x) == ["Unused1", "Young", "Middle", "Old", "Unused2"]
+@test unique(x) == ["Young", "Middle", "Old"]
+
+x = CategoricalArray(String[])
+@test isa(levels(x), Vector{String}) && isempty(levels(x))
+@test isa(unique(x), Vector{String}) && isempty(unique(x))
+@test levels!(x, ["Young", "Middle", "Old"]) === x
+@test levels(x) == ["Young", "Middle", "Old"]
+@test isa(unique(x), Vector{String}) && isempty(unique(x))
+
+# To test short-circuit after 1000 elements
+x = CategoricalArray(repeat(1:1500, inner=10))
+@test levels(x) == collect(1:1500)
+@test unique(x) == collect(1:1500)
+@test levels!(x, [1600:-1:1; 2000]) === x
+@test levels(x) == [1600:-1:1; 2000]
+@test unique(x) == collect(1500:-1:1)
+
 end

--- a/test/14_view.jl
+++ b/test/14_view.jl
@@ -2,14 +2,21 @@ module TestView
 
 using Base.Test
 using CategoricalArrays
+using NullableArrays
 
-for T in [CategoricalArray, NullableCategoricalArray]
-    for order in [true, false]
-        x = T(1:10, ordered=order)
-        for inds in [1:2, :, 1, []]
-            v = view(x, inds)
-            @test levels(v) === levels(x)
-            @test isordered(v) === isordered(x)
+# == currently throws an error for Nullables
+(==) = isequal
+
+for (A, T) in zip((Array, NullableArray), (CategoricalArray, NullableCategoricalArray))
+    for order in (true, false)
+        for a in (1:10, 10:-1:1, ["a", "c", "b", "b", "a"])
+            for inds in [1:2, :, 1, []]
+                x = T(a, ordered=order)
+                v = view(x, inds)
+                @test levels(v) === levels(x)
+                @test unique(v) == (ndims(v) > 0 ? sort(A(unique(a[inds]))) : A([a[inds]]))
+                @test isordered(v) === isordered(x)
+            end
         end
     end
 end


### PR DESCRIPTION
Faster, and respects the order of levels. Use it for droplevels!() to avoid
duplication. This introduces a dependency on NullableArrays in order to return
a NulableArray rather than an Array{Nullable} from
unique(::NullableCategoricalArray).

Fix a bug in levels!() when encountering a null value (uncovered by new
tests).