### PR TITLE
Implement getindex() for non-scalars

### DIFF
--- a/test/11_array.jl
+++ b/test/11_array.jl
@@ -123,8 +123,34 @@ for ordered in (false, true)
         @test x[3] === x.pool.valindex[1]
         @test_throws BoundsError x[4]
 
-        @test x[1:2] == ["b", "a"]
-        @test typeof(x[1:2]) === typeof(x)
+        x2 = x[:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test x2 !== x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:2]
+        @test typeof(x2) === typeof(x)
+        @test x2 == ["b", "a"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1]
+        @test typeof(x2) === typeof(x)
+        @test x2 == ["b"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[2:1]
+        @test typeof(x2) === typeof(x)
+        @test isempty(x2)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
         x[1] = x[2]
         @test x[1] === x.pool.valindex[2]
@@ -318,8 +344,33 @@ for ordered in (false, true)
         @test x[4] === x.pool.valindex[4]
         @test_throws BoundsError x[5]
 
-        @test x[1:2] == [0.0, 0.5]
-        @test typeof(x[1:2]) === typeof(x)
+        x2 = x[:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:2]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0, 0.5]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1]
+        @test typeof(x2) === typeof(x)
+        @test x2 == [0.0]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[2:1]
+        @test typeof(x2) === typeof(x)
+        @test isempty(x2)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
         x[2] = 1
         @test x[1] === x.pool.valindex[1]
@@ -481,10 +532,37 @@ for ordered in (false, true)
         @test_throws BoundsError x[4,1]
         @test_throws BoundsError x[4,4]
 
-        @test x[1:2,:] == x
-        @test typeof(x[1:2,:]) === typeof(x)
-        @test x[1:2,1] == ["a", "b"]
-        @test typeof(x[1:2,1]) === CategoricalVector{String, R}
+        x2 = x[1:2,:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[:,[1, 3]]
+        @test typeof(x2) === typeof(x)
+        @test x2 == ["a" "c"; "b" "c"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1,2]
+        @test isa(x2, CategoricalVector{String, R})
+        @test x2 == ["b"]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:0,:]
+        @test typeof(x2) === typeof(x)
+        @test size(x2) == (0,3)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        @test_throws BoundsError x[1:4, :]
+        @test_throws BoundsError x[1:1, -1:1]
+        @test_throws BoundsError x[4, :]
 
         x[1] = "z"
         @test x[1] === x.pool.valindex[4]
@@ -508,6 +586,15 @@ for ordered in (false, true)
         @test x[1] === x.pool.valindex[4]
         @test x[2] === x.pool.valindex[2]
         @test x[3] === x.pool.valindex[4]
+        @test x[4] === x.pool.valindex[1]
+        @test x[5] === x.pool.valindex[1]
+        @test x[6] === x.pool.valindex[3]
+        @test levels(x) == ["a", "b", "c", "z"]
+
+        x[1,2] = "b"
+        @test x[1] === x.pool.valindex[4]
+        @test x[2] === x.pool.valindex[2]
+        @test x[3] === x.pool.valindex[2]
         @test x[4] === x.pool.valindex[1]
         @test x[5] === x.pool.valindex[1]
         @test x[6] === x.pool.valindex[3]

--- a/test/12_nullablearray.jl
+++ b/test/12_nullablearray.jl
@@ -138,8 +138,34 @@ for ordered in (false, true)
             @test x[3] === Nullable(x.pool.valindex[1])
             @test_throws BoundsError x[4]
 
-            @test x[1:2] == Nullable{String}["b", "a"]
-            @test typeof(x[1:2]) === typeof(x)
+            x2 = x[:]
+            @test typeof(x2) === typeof(x)
+            @test x2 == x
+            @test x2 !== x
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[2:3]
+            @test typeof(x2) === typeof(x)
+            @test x2 == Nullable{String}["a", "b"]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:1]
+            @test typeof(x2) === typeof(x)
+            @test x2 == Nullable{String}["b"]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[2:1]
+            @test typeof(x2) === typeof(x)
+            @test isempty(x2)
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
 
             x[1] = x[2]
             @test x[1] === Nullable(x.pool.valindex[2])
@@ -339,11 +365,34 @@ for ordered in (false, true)
             @test x[3] === eltype(x)()
             @test_throws BoundsError x[4]
 
-            @test x[1:2] == Nullable{String}["a", "b"]
-            @test typeof(x[1:2]) === typeof(x)
+            x2 = x[:]
+            @test typeof(x2) === typeof(x)
+            @test x2 == x
+            @test x2 !== x
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
 
-            @test x[2:3] == Nullable{String}["b", Nullable()]
-            @test typeof(x[2:3]) === typeof(x)
+            x2 = x[2:3]
+            @test typeof(x2) === typeof(x)
+            @test x2 == Nullable{String}["b", Nullable()]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:1]
+            @test typeof(x2) === typeof(x)
+            @test x2 == Nullable{String}["a"]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[2:1]
+            @test typeof(x2) === typeof(x)
+            @test isempty(x2)
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
 
             x[1] = "b"
             @test x[1] === Nullable(x.pool.valindex[2])
@@ -496,8 +545,34 @@ for ordered in (false, true)
         @test x[4] === Nullable(x.pool.valindex[4])
         @test_throws BoundsError x[5]
 
-        @test x[1:2] == Nullable{Float64}[0.0, 0.5]
-        @test typeof(x[1:2]) === typeof(x)
+        x2 = x[:]
+        @test typeof(x2) === typeof(x)
+        @test x2 == x
+        @test x2 !== x
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:2]
+        @test typeof(x2) === typeof(x)
+        @test x2 == Nullable{Float64}[0.0, 0.5]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[1:1]
+        @test typeof(x2) === typeof(x)
+        @test x2 == Nullable{Float64}[0.0]
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
+
+        x2 = x[2:1]
+        @test typeof(x2) === typeof(x)
+        @test isempty(x2)
+        @test levels(x2) == levels(x)
+        @test levels(x2) !== levels(x)
+        @test isordered(x2) == isordered(x)
 
         x[2] = 1
         @test x[1] === Nullable(x.pool.valindex[1])
@@ -820,10 +895,37 @@ for ordered in (false, true)
             @test_throws BoundsError x[4,1]
             @test_throws BoundsError x[4,4]
 
-            @test x[1:2,:] == x
-            @test typeof(x[1:2,:]) === typeof(x)
-            @test x[1:2,1] == Nullable{String}["a", "b"]
-            @test typeof(x[1:2,1]) === NullableCategoricalVector{String, R}
+            x2 = x[1:2,:]
+            @test typeof(x2) === typeof(x)
+            @test x2 == x
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[:,[1, 3]]
+            @test typeof(x2) === typeof(x)
+            @test x2 == Nullable{String}["a" "c"; "b" Nullable()]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:1,2]
+            @test isa(x2, NullableCategoricalVector{String, R})
+            @test x2 == [Nullable()]
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            x2 = x[1:0,:]
+            @test typeof(x2) === typeof(x)
+            @test size(x2) == (0,3)
+            @test levels(x2) == levels(x)
+            @test levels(x2) !== levels(x)
+            @test isordered(x2) == isordered(x)
+
+            @test_throws BoundsError x[1:4, :]
+            @test_throws BoundsError x[1:1, -1:1]
+            @test_throws BoundsError x[4, :]
 
             x[1] = "z"
             @test x[1] === Nullable(x.pool.valindex[4])
@@ -879,6 +981,23 @@ for ordered in (false, true)
             @test x[6] === eltype(x)()
             @test levels(x) == ["a", "b", "c", "z"]
 
+            x[1,2] = Nullable("a")
+            @test x[1] === eltype(x)()
+            @test x[2] === Nullable(x.pool.valindex[2])
+            @test x[3] === Nullable(x.pool.valindex[1])
+            @test x[4] === eltype(x)()
+            @test x[5] === Nullable(x.pool.valindex[1])
+            @test x[6] === eltype(x)()
+            @test levels(x) == ["a", "b", "c", "z"]
+
+            x[2,1] = Nullable()
+            @test x[1] === eltype(x)()
+            @test x[2] === eltype(x)()
+            @test x[3] === Nullable(x.pool.valindex[1])
+            @test x[4] === eltype(x)()
+            @test x[5] === Nullable(x.pool.valindex[1])
+            @test x[6] === eltype(x)()
+            @test levels(x) == ["a", "b", "c", "z"]
 
             # Constructor with values plus missingness array
             x = NullableCategoricalArray(1:3, [true, false, true], ordered=ordered)

--- a/test/13_arraycommon.jl
+++ b/test/13_arraycommon.jl
@@ -73,6 +73,28 @@ for (CA, A) in ((CategoricalArray, Array), (NullableCategoricalArray, NullableAr
     @test r == A(vcat(a1, a2))
     @test levels(r) == ["Young", "Middle", "Old"]
     @test isordered(r) == false
+
+
+    # Test similar()
+    x = CA(["Old", "Young", "Middle", "Young"])
+    y = similar(x)
+    @test typeof(x) === typeof(y)
+    @test size(y) == size(x)
+
+    x = CA(["Old", "Young", "Middle", "Young"])
+    y = similar(x, 3)
+    @test typeof(x) === typeof(y)
+    @test size(y) == (3,)
+
+    x = CA{String, 1, UInt8}(["Old", "Young", "Middle", "Young"])
+    y = similar(x, Int)
+    @test isa(y, CA{Int, 1, UInt8})
+    @test size(y) == size(x)
+
+    x = CA(["Old", "Young", "Middle", "Young"])
+    y = similar(x, Int, 3, 2)
+    @test isa(y, CA{Int, 2, CategoricalArrays.DefaultRefType})
+    @test size(y) == (3, 2)
 end
 
 end


### PR DESCRIPTION
We need to copy the levels, which the AbstractArray fallback does not do.
Check bounds directly so that the error message does not mention the refs field.

Also make the scalar getindex() function more general (it only worked for vectors).

Fixes https://github.com/JuliaStats/DataFrames.jl/issues/1095.

Cc: @dmbates @kleinschmidt