### PR TITLE
Do not print type information when `:compact=>true`

### DIFF
--- a/src/value.jl
+++ b/src/value.jl
@@ -101,7 +101,8 @@ Base.convert(::Type{Union{S, Nothing}}, x::CategoricalValue) where {S <: Support
 Base.Broadcast.broadcastable(x::CategoricalValue) = Ref(x)
 
 function Base.show(io::IO, x::CategoricalValue)
-    if nonmissingtype(get(io, :typeinfo, Any)) === nonmissingtype(typeof(x))
+    if get(io, :compact, false) ||
+        nonmissingtype(get(io, :typeinfo, Any)) === nonmissingtype(typeof(x))
         show(io, unwrap(x))
     else
         print(io, typeof(x))

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -47,6 +47,14 @@ using CategoricalArrays
     @test sprint(show, ov2, context=:typeinfo=>typeof(ov2)) == "\"b\""
     @test sprint(show, ov3, context=:typeinfo=>typeof(ov3)) == "\"a\""
 
+    @test sprint(show, nv1, context=:compact=>true) == "\"c\""
+    @test sprint(show, nv2, context=:compact=>true) == "\"b\""
+    @test sprint(show, nv3, context=:compact=>true) == "\"a\""
+
+    @test sprint(show, ov1, context=:compact=>true) == "\"c\""
+    @test sprint(show, ov2, context=:compact=>true) == "\"b\""
+    @test sprint(show, ov3, context=:compact=>true) == "\"a\""
+
     @test sprint(print, nv1) == sprint(print, ov1) == "c"
     @test sprint(print, nv2) == sprint(print, ov2) == "b"
     @test sprint(print, nv3) == sprint(print, ov3) == "a"


### PR DESCRIPTION
`:compact=>true` used to be recommended only to print fewer digits for numbers, but now the convention appears to be to use it more generally. This is not needed for `CategoricalArray` printing as they already set `:typeinfo`, but it can help in other contexts such as when `NamedArray` dimension names are `CategoricalValue`s.

Fixes https://github.com/nalimilan/FreqTables.jl/issues/66.