### PR TITLE
Make show method for CategoricalValue three-argument

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -35,15 +35,10 @@ Base.copy(pool::CategoricalPool{T, R}) where {T, R} =
                           pool.ordered, pool.hash)
 
 function Base.show(io::IO, pool::CategoricalPool{T, R}) where {T, R}
-    @static if VERSION >= v"1.6.0"
-        @printf(io, "%s{%s, %s}([%s])", CategoricalPool, T, R,
-                join(map(repr, pool.levels), ", "))
-    else
-        @printf(io, "%s{%s,%s}([%s])", CategoricalPool, T, R,
-                join(map(repr, pool.levels), ", "))
-    end
-
-    pool.ordered && print(io, " with ordered levels")
+    @printf(io, "%s{%s, %s}([%s]", CategoricalPool, T, R,
+        join(map(repr, pool.levels), ", "))
+    pool.ordered && print(io, ", true")
+    print(io, ")")
 end
 
 Base.length(pool::CategoricalPool) = length(pool.levels)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -36,7 +36,7 @@ Base.copy(pool::CategoricalPool{T, R}) where {T, R} =
 
 function Base.show(io::IO, pool::CategoricalPool{T, R}) where {T, R}
     @printf(io, "%s{%s, %s}([%s]", CategoricalPool, T, R,
-        join(map(repr, pool.levels), ", "))
+            join(map(repr, pool.levels), ", "))
     pool.ordered && print(io, ", true")
     print(io, ")")
 end

--- a/src/value.jl
+++ b/src/value.jl
@@ -96,6 +96,14 @@ Base.convert(::Type{S}, x::CategoricalValue) where {S <: SupportedTypes} =
 
 Base.Broadcast.broadcastable(x::CategoricalValue) = Ref(x)
 
+function Base.show(io::IO, x::CategoricalValue)
+    print(io, "CategoricalValue(")
+    show(io, pool(x))
+    print(io, ", ")
+    print(io, Int(refcode(x)))
+    print(io, ")")
+end
+
 function Base.show(io::IO, ::MIME"text/plain", x::CategoricalValue)
     if get(io, :compact, false) ||
         nonmissingtype(get(io, :typeinfo, Any)) === nonmissingtype(typeof(x))

--- a/src/value.jl
+++ b/src/value.jl
@@ -96,14 +96,14 @@ Base.convert(::Type{S}, x::CategoricalValue) where {S <: SupportedTypes} =
 
 Base.Broadcast.broadcastable(x::CategoricalValue) = Ref(x)
 
-function Base.show(io::IO, x::CategoricalValue)
+function Base.show(io::IO, ::MIME"text/plain", x::CategoricalValue)
     if get(io, :compact, false) ||
         nonmissingtype(get(io, :typeinfo, Any)) === nonmissingtype(typeof(x))
-        show(io, unwrap(x))
+        show(io, MIME("text/plain"), unwrap(x))
     else
         print(io, typeof(x))
         print(io, ' ')
-        show(io, unwrap(x))
+        show(io, MIME("text/plain"), unwrap(x))
         if isordered(pool(x))
             @printf(io, " (%i/%i)", levelcode(x), length(pool(x)))
         end

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -22,9 +22,9 @@ using CategoricalArrays
     @test repr(MIME("text/plain"), nv2) == "$CategoricalValue{String, UInt32} \"b\""
     @test repr(MIME("text/plain"), nv3) == "$CategoricalValue{String, UInt32} \"a\""
 
-    @test repr(nv1) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000001)"
-    @test repr(nv2) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000002)"
-    @test repr(nv3) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000003)"
+    @test repr(nv1) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 1)"
+    @test repr(nv2) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 2)"
+    @test repr(nv3) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 3)"
     @test nv1 == eval(Meta.parse(repr(nv1)))
     @test nv2 == eval(Meta.parse(repr(nv2)))
     @test nv3 == eval(Meta.parse(repr(nv3)))
@@ -33,9 +33,9 @@ using CategoricalArrays
     @test repr(MIME"text/plain"(), ov2) == "$CategoricalValue{String, UInt32} \"b\" (2/3)"
     @test repr(MIME"text/plain"(), ov3) == "$CategoricalValue{String, UInt32} \"a\" (3/3)"
 
-    @test repr(ov1) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000001)"
-    @test repr(ov2) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000002)"
-    @test repr(ov3) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000003)"
+    @test repr(ov1) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 1)"
+    @test repr(ov2) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 2)"
+    @test repr(ov3) == "CategoricalValue($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 3)"
     @test ov1 == eval(Meta.parse(repr(ov1)))
     @test ov2 == eval(Meta.parse(repr(ov2)))
     @test ov3 == eval(Meta.parse(repr(ov3)))

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -15,45 +15,40 @@ using CategoricalArrays
     ov2 = CategoricalValue(opool, 2)
     ov3 = CategoricalValue(opool, 3)
 
-    if VERSION >= v"1.6.0"
-        @test sprint(show, pool) == "$CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"])"
-        @test sprint(show, opool) == "$CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]) with ordered levels"
+    @test repr(MIME("text/plain"), pool) == "$CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"])"
+    @test repr(MIME("text/plain"), opool) == "$CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true)"
 
-        @test sprint(show, nv1) == repr(nv1) == "$CategoricalValue{String, UInt32} \"c\""
-        @test sprint(show, nv2) == repr(nv2) == "$CategoricalValue{String, UInt32} \"b\""
-        @test sprint(show, nv3) == repr(nv3) == "$CategoricalValue{String, UInt32} \"a\""
+    @test repr(MIME("text/plain"), nv1) == "$CategoricalValue{String, UInt32} \"c\""
+    @test repr(MIME("text/plain"), nv2) == "$CategoricalValue{String, UInt32} \"b\""
+    @test repr(MIME("text/plain"), nv3) == "$CategoricalValue{String, UInt32} \"a\""
 
-        @test sprint(show, ov1) == repr(ov1) == "$CategoricalValue{String, UInt32} \"c\" (1/3)"
-        @test sprint(show, ov2) == repr(ov2) == "$CategoricalValue{String, UInt32} \"b\" (2/3)"
-        @test sprint(show, ov3) == repr(ov3) == "$CategoricalValue{String, UInt32} \"a\" (3/3)"
-    else
-        @test sprint(show, pool) == "$CategoricalPool{String,UInt32}([\"c\", \"b\", \"a\"])"
-        @test sprint(show, opool) == "$CategoricalPool{String,UInt32}([\"c\", \"b\", \"a\"]) with ordered levels"
+    @test nv1 == eval(Meta.parse(repr(nv1)))
+    @test nv2 == eval(Meta.parse(repr(nv2)))
+    @test nv3 == eval(Meta.parse(repr(nv3)))
 
-        @test sprint(show, nv1) == repr(nv1) == "$CategoricalValue{String,UInt32} \"c\""
-        @test sprint(show, nv2) == repr(nv2) == "$CategoricalValue{String,UInt32} \"b\""
-        @test sprint(show, nv3) == repr(nv3) == "$CategoricalValue{String,UInt32} \"a\""
+    @test repr(MIME"text/plain"(), ov1) == "$CategoricalValue{String, UInt32} \"c\" (1/3)"
+    @test repr(MIME"text/plain"(), ov2) == "$CategoricalValue{String, UInt32} \"b\" (2/3)"
+    @test repr(MIME"text/plain"(), ov3) == "$CategoricalValue{String, UInt32} \"a\" (3/3)"
 
-        @test sprint(show, ov1) == repr(ov1) == "$CategoricalValue{String,UInt32} \"c\" (1/3)"
-        @test sprint(show, ov2) == repr(ov2) == "$CategoricalValue{String,UInt32} \"b\" (2/3)"
-        @test sprint(show, ov3) == repr(ov3) == "$CategoricalValue{String,UInt32} \"a\" (3/3)"
-    end
+    @test ov1 == eval(Meta.parse(repr(ov1)))
+    @test ov2 == eval(Meta.parse(repr(ov2)))
+    @test ov3 == eval(Meta.parse(repr(ov3)))
 
-    @test sprint(show, nv1, context=:typeinfo=>typeof(nv1)) == "\"c\""
-    @test sprint(show, nv2, context=:typeinfo=>typeof(nv2)) == "\"b\""
-    @test sprint(show, nv3, context=:typeinfo=>typeof(nv3)) == "\"a\""
+    @test repr(MIME("text/plain"), nv1, context=:typeinfo=>typeof(nv1)) == "\"c\""
+    @test repr(MIME("text/plain"), nv2, context=:typeinfo=>typeof(nv2)) == "\"b\""
+    @test repr(MIME("text/plain"), nv3, context=:typeinfo=>typeof(nv3)) == "\"a\""
 
-    @test sprint(show, ov1, context=:typeinfo=>typeof(ov1)) == "\"c\""
-    @test sprint(show, ov2, context=:typeinfo=>typeof(ov2)) == "\"b\""
-    @test sprint(show, ov3, context=:typeinfo=>typeof(ov3)) == "\"a\""
+    @test repr(MIME("text/plain"), ov1, context=:typeinfo=>typeof(ov1)) == "\"c\""
+    @test repr(MIME("text/plain"), ov2, context=:typeinfo=>typeof(ov2)) == "\"b\""
+    @test repr(MIME("text/plain"), ov3, context=:typeinfo=>typeof(ov3)) == "\"a\""
 
-    @test sprint(show, nv1, context=:compact=>true) == "\"c\""
-    @test sprint(show, nv2, context=:compact=>true) == "\"b\""
-    @test sprint(show, nv3, context=:compact=>true) == "\"a\""
+    @test repr(MIME("text/plain"), nv1, context=:compact=>true) == "\"c\""
+    @test repr(MIME("text/plain"), nv2, context=:compact=>true) == "\"b\""
+    @test repr(MIME("text/plain"), nv3, context=:compact=>true) == "\"a\""
 
-    @test sprint(show, ov1, context=:compact=>true) == "\"c\""
-    @test sprint(show, ov2, context=:compact=>true) == "\"b\""
-    @test sprint(show, ov3, context=:compact=>true) == "\"a\""
+    @test repr(MIME("text/plain"), ov1, context=:compact=>true) == "\"c\""
+    @test repr(MIME("text/plain"), ov2, context=:compact=>true) == "\"b\""
+    @test repr(MIME("text/plain"), ov3, context=:compact=>true) == "\"a\""
 
     @test sprint(print, nv1) == sprint(print, ov1) == "c"
     @test sprint(print, nv2) == sprint(print, ov2) == "b"

--- a/test/06_show.jl
+++ b/test/06_show.jl
@@ -22,6 +22,9 @@ using CategoricalArrays
     @test repr(MIME("text/plain"), nv2) == "$CategoricalValue{String, UInt32} \"b\""
     @test repr(MIME("text/plain"), nv3) == "$CategoricalValue{String, UInt32} \"a\""
 
+    @test repr(nv1) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000001)"
+    @test repr(nv2) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000002)"
+    @test repr(nv3) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"]), 0x00000003)"
     @test nv1 == eval(Meta.parse(repr(nv1)))
     @test nv2 == eval(Meta.parse(repr(nv2)))
     @test nv3 == eval(Meta.parse(repr(nv3)))
@@ -30,6 +33,9 @@ using CategoricalArrays
     @test repr(MIME"text/plain"(), ov2) == "$CategoricalValue{String, UInt32} \"b\" (2/3)"
     @test repr(MIME"text/plain"(), ov3) == "$CategoricalValue{String, UInt32} \"a\" (3/3)"
 
+    @test repr(ov1) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000001)"
+    @test repr(ov2) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000002)"
+    @test repr(ov3) == "$CategoricalValue{String, UInt32}($CategoricalPool{String, UInt32}([\"c\", \"b\", \"a\"], true), 0x00000003)"
     @test ov1 == eval(Meta.parse(repr(ov1)))
     @test ov2 == eval(Meta.parse(repr(ov2)))
     @test ov3 == eval(Meta.parse(repr(ov3)))


### PR DESCRIPTION
Also, adjust two-argument show method for CategoricalPool such that it produces parseable results. With this change, I'm getting

```julia
julia> [String7("placebo")]
1-element Vector{String7}:
 "placebo"

julia> categorical([String7("placebo")])
1-element CategoricalArray{String7,1,UInt32}:
 "placebo"
```

Closes #435 